### PR TITLE
태그 입력란 컴포넌트 구현

### DIFF
--- a/src/app/(header)/projects/new/page.tsx
+++ b/src/app/(header)/projects/new/page.tsx
@@ -1,4 +1,4 @@
-import { CreateForm } from '@/features/project/components/new/CreateForm';
+import { CreateForm } from '@/features/project/components/create-form/CreateForm';
 
 export default function NewProjectPage() {
   return (

--- a/src/components/text-input/TextInput.tsx
+++ b/src/components/text-input/TextInput.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { cn } from '@/utils/style';
 import { InputHTMLAttributes } from 'react';
 
 export type TextInputProps = InputHTMLAttributes<HTMLInputElement>;
@@ -21,10 +20,7 @@ export function TextInput({
       onChange={onChange}
       maxLength={maxLength}
       disabled={disabled}
-      className={cn(
-        'px-4 py-3 placeholder:text-grey rounded-md outline-none border focus:border-transparent border-grey focus:ring-2 focus:ring-blue focus:ring-offset-0',
-        disabled && 'bg-blue-white',
-      )}
+      className="px-4 py-3 placeholder:text-grey rounded-md outline-none border focus:border-transparent border-grey focus:ring-2 focus:ring-blue focus:ring-offset-0 disabled:bg-blue-white"
     />
   );
 }

--- a/src/features/project/components/create-form/CreateForm.tsx
+++ b/src/features/project/components/create-form/CreateForm.tsx
@@ -5,11 +5,13 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { FormProvider, useForm } from 'react-hook-form';
 import { NewProject, newProjectSchema } from '../../schemas';
 import { ImageUploader } from '../image-uploader';
+import { TagInput } from '../tag';
 
 export function CreateForm() {
   const methods = useForm<NewProject>({
     defaultValues: {
       images: [],
+      tags: [],
     },
     resolver: zodResolver(newProjectSchema),
   });
@@ -29,6 +31,7 @@ export function CreateForm() {
           required
           maxImages={5}
         />
+        <TagInput name="tags" label="태그" required maxTags={5} />
         <Button type="submit">생성하기</Button>
       </form>
     </FormProvider>

--- a/src/features/project/components/create-form/index.ts
+++ b/src/features/project/components/create-form/index.ts
@@ -1,0 +1,1 @@
+export * from './CreateForm';

--- a/src/features/project/components/index.ts
+++ b/src/features/project/components/index.ts
@@ -1,1 +1,2 @@
 export * from './image-uploader';
+export * from './tag';

--- a/src/features/project/components/new/index.ts
+++ b/src/features/project/components/new/index.ts
@@ -1,1 +1,0 @@
-export * from './CreateForm';

--- a/src/features/project/components/tag/ControlledTagInput.tsx
+++ b/src/features/project/components/tag/ControlledTagInput.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { FormFieldWrapper } from '@/components/form';
+import { Controller, useFormContext } from 'react-hook-form';
+import { TagInput } from './TagInput';
+
+type ControlledTagInputProps = {
+  name: string;
+  label?: string;
+  required?: boolean;
+  maxTags?: number;
+};
+
+export function ControlledTagInput({
+  name,
+  label,
+  required,
+  maxTags = 5,
+}: ControlledTagInputProps) {
+  const { control } = useFormContext();
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field }) => (
+        <FormFieldWrapper name={name} label={label} required={required}>
+          <TagInput
+            value={field.value || []}
+            onChange={field.onChange}
+            maxTags={maxTags}
+          />
+        </FormFieldWrapper>
+      )}
+    />
+  );
+}

--- a/src/features/project/components/tag/TagInput.tsx
+++ b/src/features/project/components/tag/TagInput.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { cn } from '@/utils/style';
+import { useTagInput } from '../../hooks';
+import { TagList } from './TagList';
+
+type TagInputProps = {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  maxTags?: number;
+};
+
+export function TagInput({ value, onChange, maxTags = 5 }: TagInputProps) {
+  const { tagValue, handleChange, handleKeyDown, removeTag } = useTagInput(
+    value,
+    onChange,
+    maxTags,
+  );
+
+  return (
+    <div className={cn('flex flex-col w-full', value.length !== 0 && 'gap-2')}>
+      <input
+        type="text"
+        value={tagValue}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder="태그를 입력해주세요 (Enter로 추가)"
+        className="px-4 py-3 placeholder:text-grey rounded-md outline-none border focus:border-transparent border-grey focus:ring-2 focus:ring-blue focus:ring-offset-0 disabled:bg-blue-white"
+        disabled={value.length >= maxTags}
+      />
+      <TagList tags={value} removeTag={removeTag} />
+    </div>
+  );
+}

--- a/src/features/project/components/tag/TagInput.tsx
+++ b/src/features/project/components/tag/TagInput.tsx
@@ -19,13 +19,16 @@ export function TagInput({ value, onChange, maxTags = 5 }: TagInputProps) {
 
   return (
     <div className={cn('flex flex-col w-full', value.length !== 0 && 'gap-2')}>
+      <p className="text-grey text-sm absolute top-9 left-0">
+        * 태그는 최대 5개까지 입력할 수 있습니다.
+      </p>
       <input
         type="text"
         value={tagValue}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         placeholder="태그를 입력해주세요 (Enter로 추가)"
-        className="px-4 py-3 placeholder:text-grey rounded-md outline-none border focus:border-transparent border-grey focus:ring-2 focus:ring-blue focus:ring-offset-0 disabled:bg-blue-white"
+        className="px-4 py-3 mt-4 placeholder:text-grey rounded-md outline-none border focus:border-transparent border-grey focus:ring-2 focus:ring-blue focus:ring-offset-0 disabled:bg-blue-white"
         disabled={value.length >= maxTags}
       />
       <TagList tags={value} removeTag={removeTag} />

--- a/src/features/project/components/tag/TagItem.tsx
+++ b/src/features/project/components/tag/TagItem.tsx
@@ -1,0 +1,24 @@
+import { CancelIcon } from '@/components/icons';
+
+type TagItemProps = {
+  tag: string;
+  removeTag: () => void;
+};
+
+export function TagItem({ tag, removeTag }: TagItemProps) {
+  return (
+    <li
+      className="flex items-center gap-[6px] px-3 py-1 bg-light-blue rounded-full cursor-pointer transition-all duration-100 hover:brightness-95"
+      onClick={removeTag}
+    >
+      <span className="text-blue text-sm font-medium">{tag}</span>
+      <CancelIcon
+        width={8}
+        height={8}
+        fill="var(--color-blue)"
+        stroke="var(--color-blue)"
+        strokeWidth="2"
+      />
+    </li>
+  );
+}

--- a/src/features/project/components/tag/TagList.tsx
+++ b/src/features/project/components/tag/TagList.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/utils/style';
+import { TagItem } from './TagItem';
+
+type TagListProps = {
+  tags: string[];
+  removeTag: (index: number) => void;
+};
+
+export function TagList({ tags, removeTag }: TagListProps) {
+  return (
+    <ul className={cn('flex flex-wrap gap-2', tags.length !== 0 && 'mt-2')}>
+      {tags.map((tag, index) => (
+        <TagItem
+          key={`${tag}-${index}`}
+          tag={tag}
+          removeTag={() => removeTag(index)}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/src/features/project/components/tag/index.ts
+++ b/src/features/project/components/tag/index.ts
@@ -1,0 +1,2 @@
+export { ControlledTagInput as TagInput } from './ControlledTagInput';
+export { TagList } from './TagList';

--- a/src/features/project/hooks/index.ts
+++ b/src/features/project/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useImageUploader';
+export * from './useTagInput';

--- a/src/features/project/hooks/useTagInput.tsx
+++ b/src/features/project/hooks/useTagInput.tsx
@@ -32,21 +32,27 @@ export function useTagInput(
     }
   };
 
-  const addTag = async (tag: string) => {
+  const validateTag = (tag: string) => {
     const result = tagSchema.safeParse(tag);
     if (!result.success) {
       setError('tags', {
         type: 'manual',
         message: result.error.errors[0].message,
       });
-      return;
+      return false;
     }
 
     if (value.includes(tag) || value.length >= maxTags) {
       setTagValue('');
       setFocus('tags');
-      return;
+      return false;
     }
+
+    return true;
+  };
+
+  const addTag = async (tag: string) => {
+    if (!validateTag(tag)) return;
 
     clearErrors('tags');
     onChange([...value, tag]);

--- a/src/features/project/hooks/useTagInput.tsx
+++ b/src/features/project/hooks/useTagInput.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { ChangeEvent, KeyboardEvent, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { tagSchema } from '../schemas';
+
+export function useTagInput(
+  value: string[],
+  onChange: (tags: string[]) => void,
+  maxTags: number,
+) {
+  const [tagValue, setTagValue] = useState('');
+  const {
+    setError,
+    clearErrors,
+    trigger,
+    setFocus,
+    formState: { errors },
+  } = useFormContext();
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setTagValue(e.target.value);
+
+    if (!errors.tags) return;
+
+    const trimmedTag = e.target.value.trim();
+    if (trimmedTag !== '') {
+      const result = tagSchema.safeParse(trimmedTag);
+      if (result.success) {
+        clearErrors('tags');
+      }
+    }
+  };
+
+  const addTag = async (tag: string) => {
+    const result = tagSchema.safeParse(tag);
+    if (!result.success) {
+      setError('tags', {
+        type: 'manual',
+        message: result.error.errors[0].message,
+      });
+      return;
+    }
+
+    // 2) 중복/빈값/최대 개수 검증
+    if (value.includes(tag) || value.length >= maxTags) {
+      setTagValue('');
+      setFocus('tags');
+      return;
+    }
+
+    // 3) 성공 시: 기존 에러 제거, 값 변경, tags 배열 전체 검증 트리거
+    clearErrors('tags');
+    onChange([...value, tag]);
+    setTagValue('');
+    await trigger('tags');
+  };
+
+  const removeTag = (index: number) => {
+    const newTags = [...value];
+    newTags.splice(index, 1);
+    onChange(newTags);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+
+      if (e.nativeEvent.isComposing) return;
+
+      const trimmedTag = tagValue.trim();
+      if (trimmedTag === '') return;
+
+      addTag(trimmedTag);
+    }
+  };
+
+  return {
+    tagValue,
+    handleChange,
+    handleKeyDown,
+    removeTag,
+  };
+}

--- a/src/features/project/hooks/useTagInput.tsx
+++ b/src/features/project/hooks/useTagInput.tsx
@@ -42,14 +42,12 @@ export function useTagInput(
       return;
     }
 
-    // 2) 중복/빈값/최대 개수 검증
     if (value.includes(tag) || value.length >= maxTags) {
       setTagValue('');
       setFocus('tags');
       return;
     }
 
-    // 3) 성공 시: 기존 에러 제거, 값 변경, tags 배열 전체 검증 트리거
     clearErrors('tags');
     onChange([...value, tag]);
     setTagValue('');

--- a/src/features/project/schemas/new.ts
+++ b/src/features/project/schemas/new.ts
@@ -1,6 +1,15 @@
 import { ACCEPTED_IMAGE_TYPES, MAX_FILE_SIZE } from '@/constants';
 import { z } from 'zod';
 
+export const tagSchema = z
+  .string()
+  .min(2, '태그는 2~20자 이내로 입력해주세요.')
+  .max(20, '태그는 2~20자 이내로 입력해주세요.')
+  .regex(/^\S+$/, { message: '태그는 공백을 포함할 수 없습니다.' })
+  .regex(/^[A-Za-z0-9가-힣ㄱ-ㅎㅏ-ㅣ]+$/, {
+    message: '태그는 특수문자를 포함할 수 없습니다.',
+  });
+
 export const newProjectSchema = z.object({
   images: z
     .array(
@@ -17,6 +26,7 @@ export const newProjectSchema = z.object({
     )
     .min(1, '프로젝트 이미지를 1장 이상 업로드해 주세요.')
     .max(5, '프로젝트 이미지는 최대 5장까지 업로드 가능합니다.'),
+  tags: z.array(tagSchema).min(1, { message: '태그를 입력해주세요.' }),
 });
 
 export type NewProject = z.infer<typeof newProjectSchema>;


### PR DESCRIPTION
## ⭐Key Changes

<div align="center">
<img width="429" alt="태그 입력란" src="https://github.com/user-attachments/assets/f9710c47-0f61-4858-81c3-a14a986877f8" />
</div>

1. 태그 입력란 컴포넌트 `<TagInput>`을 구현했습니다.
2. 태그를 추가할 때 `validateTag` 함수를 통해 유효성 검증을 진행합니다.
3. 최대 5개의 태그가 가능하기 때문에, 5개를 입력한 경우 `disabled` 처리했습니다.
4. 프로젝트 정보를 나열할 때 삭제 불가능한 태그 목록은 `<TagList>` 컴포넌트를 수정하여 재사용할 수 있도록 구현할 예정입니다.

<br />

## 📌 issue

close #26 
