### PR TITLE
로그인 상태 저장

### DIFF
--- a/src/app/oauth/callback/page.tsx
+++ b/src/app/oauth/callback/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { SpinnerIcon } from '@/components/icons';
-import { AUTH_PATH, ROOT_PATH } from '@/constants';
-import { signupTokenAtom } from '@/store';
+import { AUTH_PATH } from '@/constants';
+import { useMe } from '@/features/auth/hooks';
+import { accessTokenAtom, signupTokenAtom } from '@/store';
 import { useSetAtom } from 'jotai';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
@@ -12,19 +13,24 @@ export default function LoginCallbackPage() {
   const searchParams = useSearchParams();
   const message = searchParams.get('message');
   const setSignupToken = useSetAtom(signupTokenAtom);
+  const setAccessToken = useSetAtom(accessTokenAtom);
+
+  const { mutate: getMe } = useMe();
 
   useEffect(() => {
     if (message === 'additionalInfoRequired') {
       setSignupToken(searchParams.get('signupToken'));
       router.push(AUTH_PATH.SIGN_UP);
     } else if (message === 'loginSuccess') {
-      router.push(ROOT_PATH);
+      const accessToken = searchParams.get('accessToken') as string;
+
+      setAccessToken(accessToken);
+      getMe(accessToken);
     } else {
       // 로그인 실패 처리 Toast
       router.push(AUTH_PATH.LOGIN);
     }
   }, [message]);
-
   return (
     <section className="flex h-screen w-full items-center justify-center">
       <SpinnerIcon

--- a/src/components/header/NavBar.tsx
+++ b/src/components/header/NavBar.tsx
@@ -1,10 +1,12 @@
+import { AUTH_PATH, PROJECT_PATH, ROOT_PATH } from '@/constants';
+import { useLogout } from '@/features/auth/hooks';
 import { useOutsideClick } from '@/hooks';
-import { navbarAtom } from '@/store';
+import { isLoggedInAtom, navbarAtom } from '@/store';
 import { cn } from '@/utils/style';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
+import Link from 'next/link';
 import { RefObject, useRef } from 'react';
 import { NavMenuItem } from './NavMenuItem';
-import { MENU_HEIGHT, MENU_LIST } from './menu';
 
 type NavbarProps = {
   triggerRef: RefObject<HTMLButtonElement | null>;
@@ -13,12 +15,31 @@ type NavbarProps = {
 export function NavBar({ triggerRef }: NavbarProps) {
   const navbarRef = useRef<HTMLElement>(null);
   const [isNavbarOpen, setIsNavbarOpen] = useAtom(navbarAtom);
-
+  const isLoggedIn = useAtomValue(isLoggedInAtom);
   const refs = triggerRef ? [navbarRef, triggerRef] : navbarRef;
+
+  const { mutate: logout } = useLogout();
+
+  const menuList = [
+    {
+      label: '홈으로',
+      href: ROOT_PATH,
+    },
+    {
+      label: '프로젝트',
+      href: PROJECT_PATH.ROOT,
+    },
+  ];
+  const menuHeight = `${1 + 3 * (menuList.length + 1)}rem`;
 
   useOutsideClick(refs, () => {
     if (isNavbarOpen) setIsNavbarOpen(false);
   });
+
+  const handleLogoutClick = () => {
+    logout();
+    setIsNavbarOpen(false);
+  };
   return (
     <nav
       ref={navbarRef}
@@ -26,12 +47,32 @@ export function NavBar({ triggerRef }: NavbarProps) {
         'px-8 bg-white transition-all duration-200 ease-in-out z-40',
         isNavbarOpen ? 'pb-4 border-b border-soft-grey' : 'h-0 overflow-hidden',
       )}
-      style={{ height: isNavbarOpen ? MENU_HEIGHT : '0' }}
+      style={{ height: isNavbarOpen ? menuHeight : '0' }}
     >
       <ul>
-        {MENU_LIST.map((menu) => (
+        {menuList.map((menu) => (
           <NavMenuItem key={menu.href} label={menu.label} href={menu.href} />
         ))}
+        {isLoggedIn ? (
+          <li className="flex w-full h-12">
+            <button
+              className="flex items-center px-4 w-full h-full hover:bg-light-blue rounded-md transition-colors duration-200 cursor-pointer"
+              onClick={handleLogoutClick}
+            >
+              로그아웃
+            </button>
+          </li>
+        ) : (
+          <li className="flex w-full h-12">
+            <Link
+              href={AUTH_PATH.LOGIN}
+              className="flex items-center px-4 w-full h-full hover:bg-light-blue rounded-md transition-colors duration-200"
+              onClick={() => setIsNavbarOpen(false)}
+            >
+              로그인하러 가기
+            </Link>
+          </li>
+        )}
       </ul>
     </nav>
   );

--- a/src/features/auth/hooks/index.ts
+++ b/src/features/auth/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useCodeVerification';
 export * from './useImageUploader';
+export * from './useMe';
 export * from './useSignup';
 export * from './useSignupForm';
 export * from './useTeamList';

--- a/src/features/auth/hooks/index.ts
+++ b/src/features/auth/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useCodeVerification';
 export * from './useImageUploader';
+export * from './useLogout';
 export * from './useMe';
 export * from './useSignup';
 export * from './useSignupForm';

--- a/src/features/auth/hooks/useLogout.tsx
+++ b/src/features/auth/hooks/useLogout.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { accessTokenAtom } from '@/store';
+import { useMutation } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+import { logout } from '../services';
+
+export function useLogout() {
+  const setAccessToken = useSetAtom(accessTokenAtom);
+
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      setAccessToken(null);
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+}

--- a/src/features/auth/hooks/useMe.tsx
+++ b/src/features/auth/hooks/useMe.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { ROOT_PATH } from '@/constants';
+import { MyData } from '@/features/user/schemas';
+import { authAtom } from '@/store/atoms/user';
+import { useMutation } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+import { useRouter } from 'next/navigation';
+import { getMe } from '../services';
+
+export function useMe() {
+  const router = useRouter();
+  const setAuth = useSetAtom(authAtom);
+
+  return useMutation<MyData, Error, string>({
+    mutationFn: getMe,
+    onSuccess: ({ id, email, name, profileImageUrl, teamId }) => {
+      setAuth({
+        id,
+        email,
+        name,
+        profileImageUrl,
+        teamId,
+      });
+      router.push(ROOT_PATH);
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+}

--- a/src/features/auth/schemas/login.ts
+++ b/src/features/auth/schemas/login.ts
@@ -3,3 +3,13 @@ import { z } from 'zod';
 export const loginProviderSchema = z.enum(['kakao']);
 
 export type LoginProvider = z.infer<typeof loginProviderSchema>;
+
+export const authSchema = z.object({
+  id: z.number(),
+  email: z.string().email(),
+  name: z.string(),
+  profileImageUrl: z.string().url(),
+  teamId: z.number(),
+});
+
+export type Auth = z.infer<typeof authSchema>;

--- a/src/features/auth/services/index.ts
+++ b/src/features/auth/services/index.ts
@@ -6,6 +6,26 @@ export const loginWithProvider = async (provider: LoginProvider) => {
   window.location.href = `${BASE_URL}/api/oauth/${provider}/redirection`;
 };
 
+export const logout = async () => {
+  try {
+    const response = await fetch(`${BASE_URL}/api/auth/tokens`, {
+      method: 'DELETE',
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error('Failed to logout:', error);
+
+    throw error instanceof Error
+      ? error
+      : new Error('An unexpected error occurred while logging out');
+  }
+};
+
 export const getMe = async (token: string) => {
   try {
     const response = await fetch(`${BASE_URL}/api/members/me`, {

--- a/src/features/auth/services/index.ts
+++ b/src/features/auth/services/index.ts
@@ -6,6 +6,30 @@ export const loginWithProvider = async (provider: LoginProvider) => {
   window.location.href = `${BASE_URL}/api/oauth/${provider}/redirection`;
 };
 
+export const getMe = async (token: string) => {
+  try {
+    const response = await fetch(`${BASE_URL}/api/members/me`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    return data.data;
+  } catch (error) {
+    console.error('Failed to get me:', error);
+
+    throw error instanceof Error
+      ? error
+      : new Error('An unexpected error occurred while fetching me');
+  }
+};
+
 export const getTeamList = async () => {
   try {
     const response = await fetch(`${BASE_URL}/api/teams`);

--- a/src/features/user/schemas/index.ts
+++ b/src/features/user/schemas/index.ts
@@ -1,0 +1,1 @@
+export * from './user';

--- a/src/features/user/schemas/user.ts
+++ b/src/features/user/schemas/user.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const myDataSchema = z.object({
+  id: z.number(),
+  teamId: z.number(),
+  email: z.string().email(),
+  password: z.string(),
+  name: z.string(),
+  nickname: z.string(),
+  course: z.string(),
+  profileImageUrl: z.string().url(),
+  role: z.enum(['USER', 'ADMIN']),
+  state: z.enum(['ACTIVE', 'INACTIVE']),
+  createdAt: z.string().datetime(),
+  modifiedAt: z.string().datetime(),
+  social: z.boolean(),
+});
+
+export type MyData = z.infer<typeof myDataSchema>;

--- a/src/providers.tsx
+++ b/src/providers.tsx
@@ -3,10 +3,12 @@
 import { getQueryClient } from '@/libs/tanstack-query';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { Provider as JotaiProvider } from 'jotai';
+
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={getQueryClient()}>
-      {children}
+      <JotaiProvider>{children}</JotaiProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/src/store/atoms/access-token.ts
+++ b/src/store/atoms/access-token.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const accessTokenAtom = atom<string | null>(null);

--- a/src/store/atoms/index.ts
+++ b/src/store/atoms/index.ts
@@ -1,3 +1,6 @@
+export * from './access-token';
 export * from './is-code-verified';
+export * from './is-logged-in';
 export * from './navbar';
 export * from './signup-token';
+export * from './user';

--- a/src/store/atoms/is-logged-in.ts
+++ b/src/store/atoms/is-logged-in.ts
@@ -1,0 +1,10 @@
+import { atom } from 'jotai';
+import { accessTokenAtom } from './access-token';
+import { authAtom } from './user';
+
+export const isLoggedInAtom = atom((get) => {
+  const auth = get(authAtom);
+  const accessToken = get(accessTokenAtom);
+
+  return Boolean(auth && accessToken);
+});

--- a/src/store/atoms/user.ts
+++ b/src/store/atoms/user.ts
@@ -1,0 +1,4 @@
+import { Auth } from '@/features/auth/schemas';
+import { atom } from 'jotai';
+
+export const authAtom = atom<Auth | null>(null);


### PR DESCRIPTION
## ⭐Key Changes

1. 로그인 성공 후 유저 정보 조회 API를 통해 유저의 정보를 가져옵니다.
2. 로그인 성공 후 받은 `access token`과 1번 API 요청의 결과를 전역 상태로 저장하고, 이를 기반으로 유저 로그인 상태를 관리하는 `isLoggedIn` 전역 상태를 생성했습니다.
3. 로그인 상태에 따른 네브바 `로그인하러가기/로그아웃` 버튼의 텍스트를 변경했습니다.

<br />

## 📌 issue

close #40 
