### PR TITLE
메인페이지 UI 퍼블리싱

### DIFF
--- a/src/app/(header)/page.tsx
+++ b/src/app/(header)/page.tsx
@@ -1,3 +1,77 @@
+import { ProjectGallery } from '@/features/project/components';
+import { SimpleCardList } from '@/features/project/components/simple-card-list';
+import { ProjectItem } from '@/features/project/schemas';
+import { Attendance } from '@/features/user/components/attendance';
+
+const latestProjects: ProjectItem[] = [
+  {
+    id: 1,
+    teamId: 101,
+    term: 2,
+    teamNumber: 1,
+    badgeImageUrl:
+      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
+    representativeImageUrl:
+      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
+    title: 'pumati',
+    introduction:
+      '카카오 테크 부트캠프 교육생의 성장 과정을 한눈에 보고, 출석까지 관리할 수 있는 교육생 중심 플랫폼입니다.카카오 테크 부트캠프 교육생의 성장 과정을 한눈에 보고, 출석까지 관리할 수 있는 교육생 중심 플랫폼입니다.',
+    tags: [
+      '풀스택',
+      '품앗이awegaawe',
+      '품앗이awegaawe',
+      '품앗이awegaawe',
+      '품앗이awegaawe',
+    ],
+    givedPumatiCount: 120,
+    receivedPumatiCount: 95,
+    createdAt: '2025-05-01T10:15:30Z',
+    modifiedAt: '2025-05-05T14:22:10Z',
+  },
+  {
+    id: 2,
+    teamId: 102,
+    term: 2,
+    teamNumber: 2,
+    badgeImageUrl:
+      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
+    representativeImageUrl:
+      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
+    title: 'goorm Dive',
+    introduction:
+      '실무자와 함께 하는 실전 프로젝트 경험, 맞춤형 멘토링을 제공하는 Deep Dive 프로그램입니다.',
+    tags: ['AI', '클라우드', '품앗이클라우드클라우드클라우', '품앗이awegaawe'],
+    givedPumatiCount: 75,
+    receivedPumatiCount: 80,
+    createdAt: '2025-04-28T09:00:00Z',
+    modifiedAt: '2025-05-03T16:45:00Z',
+  },
+  {
+    id: 3,
+    teamId: 103,
+    term: 3,
+    teamNumber: 1,
+    badgeImageUrl:
+      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
+    representativeImageUrl:
+      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
+    title: 'Campus Connect',
+    introduction:
+      '교육생들 간 네트워킹과 협업을 돕는 플랫폼으로, 프로젝트 콜라보레이션을 쉽게 관리할 수 있습니다.',
+    tags: ['풀스택', '협업'],
+    givedPumatiCount: 45,
+    receivedPumatiCount: 50,
+    createdAt: '2025-05-02T11:20:00Z',
+    modifiedAt: '2025-05-06T08:30:00Z',
+  },
+];
+
 export default function HomePage() {
-  return <div>HomePage</div>;
+  return (
+    <section className="flex flex-col gap-4 pb-15">
+      <SimpleCardList projects={latestProjects} />
+      <Attendance />
+      <ProjectGallery projects={latestProjects} />
+    </section>
+  );
 }

--- a/src/features/project/components/carousel/Carousel.tsx
+++ b/src/features/project/components/carousel/Carousel.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import Image from 'next/image';
 import { Navigation, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { ProjectImage } from '../../schemas';
 import { SwipeButton } from './SwipeButton';
 
 import 'swiper/css';
@@ -12,10 +10,10 @@ import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 
 type CarouselProps = {
-  images: ProjectImage[];
+  children: React.ReactNode[];
 };
 
-export function Carousel({ images }: CarouselProps) {
+export function Carousel({ children }: CarouselProps) {
   return (
     <article className="relative">
       <Swiper
@@ -31,19 +29,8 @@ export function Carousel({ images }: CarouselProps) {
         keyboard={{ enabled: true }}
         loop
       >
-        {images.map(({ id, url }) => (
-          <SwiperSlide key={id}>
-            <div className="relative w-full aspect-[4/3] max-h-[300px] overflow-hidden bg-blue-white">
-              <Image
-                src={url}
-                alt="프로젝트 이미지"
-                fill
-                sizes="100%"
-                className="object-contain group-hover:scale-105 transition-all duration-300"
-                priority
-              />
-            </div>
-          </SwiperSlide>
+        {children.map((child, index) => (
+          <SwiperSlide key={index}>{child}</SwiperSlide>
         ))}
         <SwipeButton direction="left" />
         <SwipeButton direction="right" />

--- a/src/features/project/components/carousel/Carousel.tsx
+++ b/src/features/project/components/carousel/Carousel.tsx
@@ -10,21 +10,22 @@ import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 
 type CarouselProps = {
+  pagination?: boolean;
   children: React.ReactNode[];
 };
 
-export function Carousel({ children }: CarouselProps) {
+export function Carousel({ children, pagination = true }: CarouselProps) {
   return (
     <article className="relative">
       <Swiper
-        modules={[Pagination, Navigation]}
+        modules={pagination ? [Pagination, Navigation] : [Navigation]}
         spaceBetween={50}
         slidesPerView={1}
         autoplay={{
           delay: 3000,
           disableOnInteraction: false,
         }}
-        pagination={{ clickable: true }}
+        pagination={pagination ? { clickable: true } : false}
         grabCursor
         keyboard={{ enabled: true }}
         loop

--- a/src/features/project/components/index.ts
+++ b/src/features/project/components/index.ts
@@ -3,5 +3,8 @@ export * from './card-list';
 export * from './create-form';
 export * from './image-uploader';
 export * from './project-detail-container';
+export * from './project-gallery';
 export * from './projects-container';
+export * from './simple-card-item';
+export * from './simple-card-list';
 export * from './tag';

--- a/src/features/project/components/project-detail-container/ProjectDetailContainer.tsx
+++ b/src/features/project/components/project-detail-container/ProjectDetailContainer.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { ProjectDetail, TeamMember } from '../../schemas';
 import { Carousel } from '../carousel';
 import { Comments } from './Comments';
@@ -152,7 +153,23 @@ export function ProjectDetailContainer() {
   return (
     <div className="flex flex-col gap-1">
       <div className="max-w-[25rem] w-full mx-auto">
-        <Carousel images={PROJECT_DETAUL_DATA.images} />
+        <Carousel>
+          {PROJECT_DETAUL_DATA.images.map(({ id, url }) => (
+            <div
+              key={id}
+              className="relative w-full aspect-[4/3] max-h-[300px] overflow-hidden bg-blue-white"
+            >
+              <Image
+                src={url}
+                alt="프로젝트 이미지"
+                fill
+                sizes="100%"
+                className="object-contain group-hover:scale-105 transition-all duration-300"
+                priority
+              />
+            </div>
+          ))}
+        </Carousel>
         <Description
           title={PROJECT_DETAUL_DATA.title}
           modifiedAt={PROJECT_DETAUL_DATA.modifiedAt}

--- a/src/features/project/components/project-gallery/ProjectGallery.tsx
+++ b/src/features/project/components/project-gallery/ProjectGallery.tsx
@@ -1,4 +1,8 @@
+'use client';
+
 import { Button } from '@/components';
+import { PROJECT_PATH } from '@/constants';
+import { useRouter } from 'next/navigation';
 import { ProjectItem } from '../../schemas';
 import { CardItem } from '../card-item';
 import { Carousel } from '../carousel';
@@ -8,6 +12,11 @@ type ProjectGalleryProps = {
 };
 
 export function ProjectGallery({ projects }: ProjectGalleryProps) {
+  const router = useRouter();
+
+  const handleBrowseProjectsClick = () => {
+    router.push(PROJECT_PATH.ROOT);
+  };
   return (
     <section className="flex flex-col gap-4 mx-auto my-10 max-w-[25rem] w-full">
       <div className="text-center">
@@ -23,7 +32,7 @@ export function ProjectGallery({ projects }: ProjectGalleryProps) {
           ))}
         </Carousel>
       </div>
-      <Button>프로젝트 둘러보기</Button>
+      <Button onClick={handleBrowseProjectsClick}>프로젝트 둘러보기</Button>
     </section>
   );
 }

--- a/src/features/project/components/project-gallery/ProjectGallery.tsx
+++ b/src/features/project/components/project-gallery/ProjectGallery.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@/components';
+import { ProjectItem } from '../../schemas';
+import { CardItem } from '../card-item';
+import { Carousel } from '../carousel';
+
+type ProjectGalleryProps = {
+  projects: ProjectItem[];
+};
+
+export function ProjectGallery({ projects }: ProjectGalleryProps) {
+  return (
+    <section className="flex flex-col gap-4 mx-auto my-10 max-w-[25rem] w-full">
+      <div className="text-center">
+        <h2 className="text-lg font-semibold">작은 아이디어가 현실로!</h2>
+        <p className="text-sm text-dark-grey">
+          교육생들의 프로젝트를 구경해보세요.
+        </p>
+      </div>
+      <div className="mb-4">
+        <Carousel pagination={false}>
+          {projects.map((project) => (
+            <CardItem key={project.id} project={project} />
+          ))}
+        </Carousel>
+      </div>
+      <Button>프로젝트 둘러보기</Button>
+    </section>
+  );
+}

--- a/src/features/project/components/project-gallery/index.ts
+++ b/src/features/project/components/project-gallery/index.ts
@@ -1,0 +1,1 @@
+export * from './ProjectGallery';

--- a/src/features/project/components/simple-card-item/SimpleCardItem.tsx
+++ b/src/features/project/components/simple-card-item/SimpleCardItem.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { PROJECT_PATH } from '@/constants';
+import { cn } from '@/utils/style';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { ProjectItem } from '../../schemas';
+import { TagList } from '../tag';
+
+type SimpleCardItemProps = {
+  project: ProjectItem;
+  rank?: number;
+};
+
+export function SimpleCardItem({ project, rank }: SimpleCardItemProps) {
+  const { id, representativeImageUrl, title, introduction, teamNumber, tags } =
+    project;
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(PROJECT_PATH.DETAIL(id.toString()));
+  };
+  return (
+    <li
+      className="flex flex-col gap-2 cursor-pointer px-4 py-3 border rounded-lg border-blue"
+      onClick={handleClick}
+    >
+      <div className="flex gap-4">
+        <div className="relative w-18 xs:w-22 h-18 xs:h-22 shrink-0">
+          <Image
+            src={representativeImageUrl}
+            alt={title}
+            fill
+            sizes="100%"
+            className="object-cover rounded-lg"
+          />
+          {rank && (
+            <span
+              className={cn(
+                'absolute overflow-hidden -top-1 -left-1 rounded-full w-6 h-6 z-10 border-2 flex items-center justify-center text-white text-sm font-bold',
+                rank === 1
+                  ? 'bg-[#FFD700] border-[#E6C200]'
+                  : rank === 2
+                    ? 'bg-[#C0C0C0] border-[#A8A8A8]'
+                    : 'bg-[#CD7F32] border-[#B87333]',
+              )}
+            >
+              <span className="absolute -bottom-1 -left-2 w-10 h-2 bg-white opacity-30 transform -rotate-45 pointer-events-none" />
+              {rank}
+            </span>
+          )}
+        </div>
+        <div className="">
+          <div className="flex justify-between items-center">
+            <h3 className="font-bold text-lg truncate">{title}</h3>
+            <span className="text-sm text-dark-grey font-semibold">
+              {teamNumber}팀
+            </span>
+          </div>
+          <p className="mt-1 text-sm xs:text-[15px] text-dark-grey line-clamp-2">
+            {introduction}
+          </p>
+        </div>
+      </div>
+      <TagList tags={tags.slice(0, 3)} />
+    </li>
+  );
+}

--- a/src/features/project/components/simple-card-item/index.ts
+++ b/src/features/project/components/simple-card-item/index.ts
@@ -1,0 +1,1 @@
+export * from './SimpleCardItem';

--- a/src/features/project/components/simple-card-list/SimpleCardList.tsx
+++ b/src/features/project/components/simple-card-list/SimpleCardList.tsx
@@ -1,0 +1,27 @@
+import { ProjectItem } from '../../schemas';
+import { SimpleCardItem } from '../simple-card-item';
+
+type SimpleCardListProps = {
+  projects: ProjectItem[];
+};
+
+export function SimpleCardList({ projects }: SimpleCardListProps) {
+  return (
+    <article className="w-full max-w-[25rem] mx-auto my-10">
+      <div className="flex flex-col gap-2 mb-8 text-center">
+        <h2 className="text-xl font-bold">
+          품앗이 상위 <span className="text-blue">TOP3</span> 프로젝트
+        </h2>
+        <p className="font-medium text-dark-grey">
+          지금 커뮤니티에서 <br />
+          가장 활발한 프로젝트들을 소개할게요!
+        </p>
+      </div>
+      <ul className="flex flex-col gap-5">
+        {projects.slice(0, 3).map((project, index) => (
+          <SimpleCardItem key={project.id} project={project} rank={index + 1} />
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/src/features/project/components/simple-card-list/index.ts
+++ b/src/features/project/components/simple-card-list/index.ts
@@ -1,0 +1,1 @@
+export * from './SimpleCardList';

--- a/src/features/user/components/attendance/Attendance.tsx
+++ b/src/features/user/components/attendance/Attendance.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Button } from '@/components';
+
+export function Attendance() {
+  const handleAttendance = () => {
+    alert('출석 체크');
+  };
+  return (
+    <article className="flex flex-col items-center justify-center gap-4 p-8 my-10 bg-blue-white">
+      <h2 className="text-lg font-semibold">오늘의 운세</h2>
+      <p className="text-center mb-4">
+        하루 한 번, 출석 체크하고 <br /> 개발자의 운세도 받아가세요!
+      </p>
+      <Button size="md" onClick={handleAttendance}>
+        출석 체크
+      </Button>
+    </article>
+  );
+}

--- a/src/features/user/components/attendance/index.ts
+++ b/src/features/user/components/attendance/index.ts
@@ -1,0 +1,1 @@
+export * from './Attendance';


### PR DESCRIPTION
## ⭐Key Changes

1. 메인페이지의 출석 섹션, 최신 프로젝트 목록 섹션, 품앗이 상위 랭킹 프로젝트 목록 섹션을 퍼블리싱했습니다.

<table>
  <thead>
    <tr>
      <th>출석</th>
      <th>최신 프로젝트 목록</th>
      <th>품앗이 상위 랭킹 프로젝트 목록</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img width="299" alt="출석" src="https://github.com/user-attachments/assets/4b9dfc37-2107-447f-8a38-057a677ea990" />
      </td>
      <td>
        <img width="313" alt="최신 프로젝트 목록" src="https://github.com/user-attachments/assets/285b51fd-e117-43dc-8ddf-1503e1bcb12f" />
      </td>
      <td>
        <img width="316" alt="품앗이 상위 랭킹 프로젝트 목록" src="https://github.com/user-attachments/assets/d7380c3f-4ee5-4085-bca9-915586c3f81c" />
      </td>
    </tr>
  </tbody>
</table>


<br />

## 🖐️To reviewers

1. `<Carousel>` 컴포넌트의 pagination을 `props`로 삭제할 수 있게 수정했습니다.
2. `<Carousel>` 컴포넌트의 `<SwiperSlide>` 컨텐츠를 전달받아 재사용성을 높였습니다.

<br />

## 📌 issue

close #53 #54 #55 
