### PR TITLE
프로젝트 목록페이지 API 연결

### DIFF
--- a/src/app/(header)/page.tsx
+++ b/src/app/(header)/page.tsx
@@ -17,11 +17,15 @@ const latestProjects: ProjectItem[] = [
     introduction:
       '카카오 테크 부트캠프 교육생의 성장 과정을 한눈에 보고, 출석까지 관리할 수 있는 교육생 중심 플랫폼입니다.카카오 테크 부트캠프 교육생의 성장 과정을 한눈에 보고, 출석까지 관리할 수 있는 교육생 중심 플랫폼입니다.',
     tags: [
-      '풀스택',
-      '품앗이awegaawe',
-      '품앗이awegaawe',
-      '품앗이awegaawe',
-      '품앗이awegaawe',
+      {
+        content: 'tag1',
+      },
+      {
+        content: 'tag2',
+      },
+      {
+        content: 'tag3',
+      },
     ],
     givedPumatiCount: 120,
     receivedPumatiCount: 95,
@@ -40,7 +44,17 @@ const latestProjects: ProjectItem[] = [
     title: 'goorm Dive',
     introduction:
       '실무자와 함께 하는 실전 프로젝트 경험, 맞춤형 멘토링을 제공하는 Deep Dive 프로그램입니다.',
-    tags: ['AI', '클라우드', '품앗이클라우드클라우드클라우', '품앗이awegaawe'],
+    tags: [
+      {
+        content: 'tag1',
+      },
+      {
+        content: 'tag2',
+      },
+      {
+        content: 'tag3',
+      },
+    ],
     givedPumatiCount: 75,
     receivedPumatiCount: 80,
     createdAt: '2025-04-28T09:00:00Z',
@@ -58,7 +72,17 @@ const latestProjects: ProjectItem[] = [
     title: 'Campus Connect',
     introduction:
       '교육생들 간 네트워킹과 협업을 돕는 플랫폼으로, 프로젝트 콜라보레이션을 쉽게 관리할 수 있습니다.',
-    tags: ['풀스택', '협업'],
+    tags: [
+      {
+        content: 'tag1',
+      },
+      {
+        content: 'tag2',
+      },
+      {
+        content: 'tag3',
+      },
+    ],
     givedPumatiCount: 45,
     receivedPumatiCount: 50,
     createdAt: '2025-05-02T11:20:00Z',

--- a/src/app/(header)/projects/page.tsx
+++ b/src/app/(header)/projects/page.tsx
@@ -1,9 +1,22 @@
+import { PROJECT_QUERY_KEY } from '@/constants/query-key';
 import { ProjectsContainer } from '@/features/project/components';
+import { getProjects, getSnapshot } from '@/features/project/services';
+import { getQueryClient } from '@/libs/tanstack-query';
 
-export default function ProjectsPage() {
+export default async function ProjectsPage() {
+  const { id } = await getSnapshot();
+
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: PROJECT_QUERY_KEY.PROJECTS,
+    queryFn: () => getProjects('rank', id),
+    staleTime: 1000 * 60 * 5,
+    initialPageParam: 0,
+  });
   return (
     <section className="flex justify-center">
-      <ProjectsContainer />
+      <ProjectsContainer contextId={id} />
     </section>
   );
 }

--- a/src/constants/query-key.ts
+++ b/src/constants/query-key.ts
@@ -1,3 +1,8 @@
 export const AUTH_QUERY_KEY = Object.freeze({
   TEAM_LIST: ['team-list'],
 });
+
+export const PROJECT_QUERY_KEY = Object.freeze({
+  PROJECTS: ['projects'],
+  SNAPSHOT: ['projects', 'snapshot'],
+});

--- a/src/features/project/components/card-item/CardItem.tsx
+++ b/src/features/project/components/card-item/CardItem.tsx
@@ -23,13 +23,13 @@ export function CardItem({ project }: CardItemProps) {
       className="flex flex-col rounded-lg overflow-hidden shadow-lg group cursor-pointer"
       onClick={handleClick}
     >
-      <div className="relative w-full aspect-[2/1] overflow-hidden">
+      <div className="relative w-full aspect-[2/1] overflow-hidden bg-black">
         <Image
           src={representativeImageUrl}
           alt={title}
           fill
           sizes="100%"
-          className="object-cover group-hover:scale-105 transition-all duration-300"
+          className="object-contain group-hover:scale-105 transition-all duration-300"
         />
       </div>
       <div className="px-4 pt-2 pb-4">
@@ -41,7 +41,7 @@ export function CardItem({ project }: CardItemProps) {
           {introduction}
         </p>
         <div className="max-h-[76px] overflow-hidden">
-          <TagList tags={tags} />
+          <TagList tags={tags.map((tag) => tag.content)} />
         </div>
       </div>
     </li>

--- a/src/features/project/components/card-list/CardList.tsx
+++ b/src/features/project/components/card-list/CardList.tsx
@@ -1,18 +1,41 @@
+import { SpinnerIcon } from '@/components/icons';
+import { cn } from '@/utils/style';
+import { RefObject } from 'react';
 import { ProjectItem } from '../../schemas';
 import { CardItem } from '../card-item';
 
 type CardListProps = {
+  ref: RefObject<HTMLDivElement | null>;
+  isFetchingNextPage: boolean;
   projects: ProjectItem[];
 };
 
-export function CardList({ projects }: CardListProps) {
+export function CardList({ ref, isFetchingNextPage, projects }: CardListProps) {
   return (
     <article className="w-full">
-      <ul className="flex flex-col gap-5">
+      <ul
+        className={cn(
+          'flex flex-col gap-5',
+          isFetchingNextPage ? 'mb-8' : 'mb-20',
+        )}
+      >
         {projects.map((project) => (
           <CardItem key={project.id} project={project} />
         ))}
       </ul>
+      <div ref={ref}>
+        {isFetchingNextPage && (
+          <div className="flex justify-center items-center gap-2 h-12 bg-blue-white text-blue">
+            <SpinnerIcon
+              width={20}
+              height={20}
+              className="animate-spin"
+              fill="var(--color-blue)"
+            />
+            <p>잠시만 기다려주세요...</p>
+          </div>
+        )}
+      </div>
     </article>
   );
 }

--- a/src/features/project/components/create-form/CreateForm.tsx
+++ b/src/features/project/components/create-form/CreateForm.tsx
@@ -33,7 +33,10 @@ export function CreateForm() {
   const { mutateAsync: createProject } = useCreateProject();
 
   const onSubmit = async (data: NewProjectForm) => {
-    if (!auth?.teamId) return;
+    if (!auth?.teamId) {
+      alert('팀 정보가 없습니다.');
+      return;
+    }
 
     setIsSubmitting(true);
     const { urls } = await uploadMultiFilesToS3(data.images);

--- a/src/features/project/components/projects-container/ProjectsContainer.tsx
+++ b/src/features/project/components/projects-container/ProjectsContainer.tsx
@@ -2,6 +2,7 @@
 
 import { CallToAction } from '@/components';
 import { PROJECT_PATH } from '@/constants';
+import { useIntersectionObserve } from '@/hooks';
 import { useRouter } from 'next/navigation';
 import { useProjects } from '../../hooks';
 import { CardList } from '../card-list';
@@ -13,17 +14,30 @@ type ProjectsContainerProps = {
 export function ProjectsContainer({ contextId }: ProjectsContainerProps) {
   const router = useRouter();
 
-  const { data, fetchNextPage, hasNextPage } = useProjects(contextId);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useProjects(contextId);
   const projects = data.pages.flatMap((page) => page.data);
+
+  const ref = useIntersectionObserve({
+    onIntersect: (entry, observer) => {
+      observer.unobserve(entry.target);
+
+      if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+    },
+  });
   return (
-    <div className="flex flex-col items-center gap-4 w-full max-w-[25rem] mb-25">
+    <div className="flex flex-col items-center gap-4 w-full max-w-[25rem]">
       <h1 className="text-xl font-semibold my-9">프로젝트 둘러보기</h1>
       <CallToAction
         text="프로젝트를 생성해보세요!"
         buttonText="생성하기"
         action={() => router.push(PROJECT_PATH.NEW)}
       />
-      <CardList projects={projects} />
+      <CardList
+        ref={ref}
+        isFetchingNextPage={isFetchingNextPage}
+        projects={projects}
+      />
     </div>
   );
 }

--- a/src/features/project/components/projects-container/ProjectsContainer.tsx
+++ b/src/features/project/components/projects-container/ProjectsContainer.tsx
@@ -3,80 +3,18 @@
 import { CallToAction } from '@/components';
 import { PROJECT_PATH } from '@/constants';
 import { useRouter } from 'next/navigation';
-import { ProjectItem } from '../../schemas';
+import { useProjects } from '../../hooks';
 import { CardList } from '../card-list';
 
-const projects: ProjectItem[] = [
-  {
-    id: 1,
-    teamId: 101,
-    term: 2,
-    teamNumber: 1,
-    badgeImageUrl:
-      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
-    representativeImageUrl:
-      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
-    title: 'pumati',
-    introduction:
-      '카카오 테크 부트캠프 교육생의 성장 과정을 한눈에 보고, 출석까지 관리할 수 있는 교육생 중심 플랫폼입니다.카카오 테크 부트캠프 교육생의 성장 과정을 한눈에 보고, 출석까지 관리할 수 있는 교육생 중심 플랫폼입니다.',
-    tags: [
-      '풀스택',
-      '품앗이awegaawe',
-      '품앗이awegaawe',
-      '품앗이awegaawe',
-      '품앗이awegaawe',
-    ],
-    givedPumatiCount: 120,
-    receivedPumatiCount: 95,
-    createdAt: '2025-05-01T10:15:30Z',
-    modifiedAt: '2025-05-05T14:22:10Z',
-  },
-  {
-    id: 2,
-    teamId: 102,
-    term: 2,
-    teamNumber: 2,
-    badgeImageUrl:
-      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
-    representativeImageUrl:
-      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
-    title: 'goorm Dive',
-    introduction:
-      '실무자와 함께 하는 실전 프로젝트 경험, 맞춤형 멘토링을 제공하는 Deep Dive 프로그램입니다.',
-    tags: [
-      'AI',
-      '클라우드',
-      '품앗이클라우드클라우드클라우드클라클라우드클라',
-      '품앗이awegaawe',
-    ],
-    givedPumatiCount: 75,
-    receivedPumatiCount: 80,
-    createdAt: '2025-04-28T09:00:00Z',
-    modifiedAt: '2025-05-03T16:45:00Z',
-  },
-  {
-    id: 3,
-    teamId: 103,
-    term: 3,
-    teamNumber: 1,
-    badgeImageUrl:
-      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
-    representativeImageUrl:
-      'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/69f83a96-2e07-457a-84ba-27de234961f6.jpg',
-    title: 'Campus Connect',
-    introduction:
-      '교육생들 간 네트워킹과 협업을 돕는 플랫폼으로, 프로젝트 콜라보레이션을 쉽게 관리할 수 있습니다.',
-    tags: ['풀스택', '협업'],
-    givedPumatiCount: 45,
-    receivedPumatiCount: 50,
-    createdAt: '2025-05-02T11:20:00Z',
-    modifiedAt: '2025-05-06T08:30:00Z',
-  },
-];
+type ProjectsContainerProps = {
+  contextId: number;
+};
 
-export function ProjectsContainer() {
+export function ProjectsContainer({ contextId }: ProjectsContainerProps) {
   const router = useRouter();
 
+  const { data, fetchNextPage, hasNextPage } = useProjects(contextId);
+  const projects = data.pages.flatMap((page) => page.data);
   return (
     <div className="flex flex-col items-center gap-4 w-full max-w-[25rem] mb-25">
       <h1 className="text-xl font-semibold my-9">프로젝트 둘러보기</h1>

--- a/src/features/project/components/simple-card-item/SimpleCardItem.tsx
+++ b/src/features/project/components/simple-card-item/SimpleCardItem.tsx
@@ -62,7 +62,7 @@ export function SimpleCardItem({ project, rank }: SimpleCardItemProps) {
           </p>
         </div>
       </div>
-      <TagList tags={tags.slice(0, 3)} />
+      <TagList tags={tags.map((tag) => tag.content)} />
     </li>
   );
 }

--- a/src/features/project/hooks/index.ts
+++ b/src/features/project/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useCreateProject';
 export * from './useImageUploader';
+export * from './useProjects';
 export * from './useTagInput';

--- a/src/features/project/hooks/useProjects.tsx
+++ b/src/features/project/hooks/useProjects.tsx
@@ -1,0 +1,15 @@
+import { PROJECT_QUERY_KEY } from '@/constants/query-key';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { ProjectInfiniteScrollResponse } from '../schemas';
+import { getProjects } from '../services';
+
+export function useProjects(contextId: number) {
+  return useSuspenseInfiniteQuery<ProjectInfiniteScrollResponse>({
+    queryKey: PROJECT_QUERY_KEY.PROJECTS,
+    queryFn: ({ pageParam }) =>
+      getProjects('rank', contextId, pageParam as number),
+    staleTime: 1000 * 60 * 5,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.meta.nextCursorId,
+  });
+}

--- a/src/features/project/schemas/project.ts
+++ b/src/features/project/schemas/project.ts
@@ -1,22 +1,16 @@
 import { z } from 'zod';
 
-export const projectItemSchema = z.object({
-  id: z.number(),
-  teamId: z.number(),
-  term: z.number(),
-  teamNumber: z.number(),
-  badgeImageUrl: z.string(),
-  representativeImageUrl: z.string(),
-  title: z.string(),
-  introduction: z.string(),
-  tags: z.array(z.string()),
-  givedPumatiCount: z.number(),
-  receivedPumatiCount: z.number(),
-  createdAt: z.string().datetime(),
-  modifiedAt: z.string().datetime(),
-});
+export type PaginationMeta = {
+  nextCursorId: number;
+  nextCursorTime: string;
+  hasNext: boolean;
+};
 
-export type ProjectItem = z.infer<typeof projectItemSchema>;
+export type InfiniteScrollResponse<T> = {
+  message: string;
+  data: T[];
+  meta: PaginationMeta;
+};
 
 const projectImageSchema = z.object({
   id: z.number(),
@@ -32,6 +26,26 @@ export type ProjectImage = z.infer<typeof projectImageSchema>;
 const projectTagSchema = z.object({
   content: z.string(),
 });
+
+export const projectItemSchema = z.object({
+  id: z.number(),
+  teamId: z.number(),
+  term: z.number(),
+  teamNumber: z.number(),
+  badgeImageUrl: z.string(),
+  representativeImageUrl: z.string(),
+  title: z.string(),
+  introduction: z.string(),
+  tags: z.array(projectTagSchema),
+  givedPumatiCount: z.number(),
+  receivedPumatiCount: z.number(),
+  createdAt: z.string().datetime(),
+  modifiedAt: z.string().datetime(),
+});
+
+export type ProjectItem = z.infer<typeof projectItemSchema>;
+
+export type ProjectInfiniteScrollResponse = InfiniteScrollResponse<ProjectItem>;
 
 export const projectDetailSchema = z.object({
   id: z.number(),

--- a/src/features/project/services/index.ts
+++ b/src/features/project/services/index.ts
@@ -31,3 +31,55 @@ export const createProject = async (
       : new Error('An unexpected error occurred while creating a project');
   }
 };
+
+export const getSnapshot = async () => {
+  try {
+    const response = await fetch(`${BASE_URL}/api/projects/snapshot`, {
+      method: 'POST',
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    return data.data;
+  } catch (error) {
+    console.error('Failed to get snapshot:', error);
+
+    throw error instanceof Error
+      ? error
+      : new Error('An unexpected error occurred while getting snapshot');
+  }
+};
+
+export const getProjects = async (
+  sort: 'rank' | 'latest',
+  contextId?: number,
+  cursorId: number = 0,
+  pageSize: number = 10,
+) => {
+  try {
+    const response = await fetch(
+      `${BASE_URL}/api/projects?sort=${sort}${contextId ? `&context-id=${contextId}` : ''}&cursor-id=${cursorId}&page-size=${pageSize}`,
+      {
+        method: 'GET',
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    return data;
+  } catch (error) {
+    console.error('Failed to get projects:', error);
+
+    throw error instanceof Error
+      ? error
+      : new Error('An unexpected error occurred while getting projects');
+  }
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useIntersectionObserver';
 export * from './useMultiFilesToS3';
 export * from './useOutsideClick';
 export * from './useUploadFileToS3';

--- a/src/hooks/useIntersectionObserver.tsx
+++ b/src/hooks/useIntersectionObserver.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+
+type IntersectionObserveOptions = {
+  onIntersect: (
+    entry: IntersectionObserverEntry,
+    observer: IntersectionObserver,
+  ) => void;
+  options?: IntersectionObserverInit;
+};
+
+export function useIntersectionObserve({
+  onIntersect,
+  options,
+}: IntersectionObserveOptions) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) onIntersect(entry, observer);
+      });
+    },
+    [onIntersect],
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+
+    return () => observer.disconnect();
+  }, [ref, options, callback]);
+
+  return ref;
+}


### PR DESCRIPTION
## ⭐Key Changes

1. 프로젝트 목록 페이지 접근 시 서버에서 프로젝트 목록 스냅샷을 가져옵니다.
2. 가져온 스냅샷 id를 사용해서 프로젝트 목록 첫 페이지를 `prefetch`합니다. 이후 `observer`를 등록하고 `observer`가 관찰되면 추가 데이터를 불러옵니다.
3. `observer`를 등록하는 커스텀 훅 `useIntersectionObserve`를 구현했습니다.
4. 추가 데이터를 가져올 때 하단에 로딩 스피너와 `잠시만 기다려주세요...` 텍스트를 보여줍니다.

<br />

## 📌 issue

close #57 #45 
