### PR TITLE
프로젝트 상세 페이지 피드백 반영

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+certificates

--- a/src/features/project/components/project-detail-container/Description.tsx
+++ b/src/features/project/components/project-detail-container/Description.tsx
@@ -78,7 +78,7 @@ export function Description({
       <TagList tags={tags.map((tag) => tag.content)} />
       <div className="flex flex-col gap-4 mt-16 mb-10">
         <h2 className="text-lg font-semibold">프로젝트 상세 설명</h2>
-        <pre className="leading-5 p-4 bg-light-grey rounded-lg whitespace-pre-wrap">
+        <pre className="leading-5 py-6 px-4 bg-light-grey rounded-lg whitespace-pre-wrap break-words">
           {detailedDescription}
         </pre>
       </div>

--- a/src/features/project/components/project-detail-container/Description.tsx
+++ b/src/features/project/components/project-detail-container/Description.tsx
@@ -73,7 +73,9 @@ export function Description({
           </div>
         </div>
       </div>
-      <p className="leading-5 mb-4">{introduction}</p>
+      <p className="leading-5 mb-4 whitespace-pre-wrap break-words">
+        {introduction}
+      </p>
       <Button onClick={handleOpenProject}>프로젝트 바로가기</Button>
       <TagList tags={tags.map((tag) => tag.content)} />
       <div className="flex flex-col gap-4 mt-16 mb-10">


### PR DESCRIPTION
- 프로젝트 상세 설명 줄바꿈 추가

## ⭐Key Changes

1. 프로젝트 상세 페이지의 "프로젝트 상세 설명" 섹션에서 긴 텍스트에 대해 줄바꿈이 되지 않는 버그를 해결했습니다. 단어 단위로 줄바꿈을 해주는 `break-words` 유틸 클래스를 추가했습니다.
<table>
  <thead>
    <tr>
      <th>적용 전</th>
      <th>적용 후</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="562" alt="적용 전" src="https://github.com/user-attachments/assets/acc04080-90bf-4c21-abe8-6cf7ac3816e3" /></td>
      <td><img width="434" alt="적용 후" src="https://github.com/user-attachments/assets/318157ec-0b3e-4ed9-ba4e-2fda75f3cfb2" /></td>
    </tr>
  </tbody>
</table>

2. 프로젝트 상세 페이지의 "한 줄 소개" 섹션도 마찬가지로 줄바꿈이 되지 않는 버그를 해결했습니다.

<br />

## 📌 issue

close #79 
