### PR TITLE
프로젝트 수정페이지 기능 구현

### DIFF
--- a/src/app/(header)/projects/[id]/edit/page.tsx
+++ b/src/app/(header)/projects/[id]/edit/page.tsx
@@ -1,18 +1,24 @@
-'use client';
+import { EditForm } from '@/features/project/components';
+import { getProject } from '@/features/project/services';
+import { notFound } from 'next/navigation';
 
-import { Button } from '@/components';
-import { useRouter } from 'next/navigation';
+type ProjectEditPageProps = {
+  params: Promise<{ id: string }>;
+};
 
-export default function ProjectEditPage() {
-  const router = useRouter();
+export default async function ProjectEditPage({
+  params,
+}: ProjectEditPageProps) {
+  const { id } = await params;
+  const project = await getProject(Number(id));
 
+  if (!project) {
+    notFound();
+  }
   return (
-    <section className="flex flex-col items-center justify-center gap-6 min-h-[calc(100vh-6rem)]">
-      <h1 className="text-xl font-semibold mt-9">프로젝트 수정</h1>
-      <p className="text-dark-grey">해당 페이지는 현재 준비 중입니다.</p>
-      <Button size="md" onClick={() => router.back()}>
-        돌아가기
-      </Button>
+    <section className="flex flex-col items-center min-h-[calc(100vh-6rem)]">
+      <h1 className="text-xl font-semibold mt-9">프로젝트 생성</h1>
+      <EditForm project={project} />
     </section>
   );
 }

--- a/src/components/icons/WarningIcon.tsx
+++ b/src/components/icons/WarningIcon.tsx
@@ -1,0 +1,34 @@
+export function WarningIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width="24px"
+      height="24px"
+      strokeWidth="1.5"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      color="#000000"
+      {...props}
+    >
+      <path
+        d="M20.0429 21H3.95705C2.41902 21 1.45658 19.3364 2.22324 18.0031L10.2662 4.01533C11.0352 2.67792 12.9648 2.67791 13.7338 4.01532L21.7768 18.0031C22.5434 19.3364 21.581 21 20.0429 21Z"
+        stroke="#000000"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      ></path>
+      <path
+        d="M12 9V13"
+        stroke="#000000"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      ></path>
+      <path
+        d="M12 17.01L12.01 16.9989"
+        stroke="#000000"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      ></path>
+    </svg>
+  );
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -8,3 +8,4 @@ export * from './PlusIcon';
 export * from './ProfileIcon';
 export * from './SpinnerIcon';
 export * from './UploadImageIcon';
+export * from './WarningIcon';

--- a/src/components/modal/ConfirmModal.tsx
+++ b/src/components/modal/ConfirmModal.tsx
@@ -9,6 +9,7 @@ type ConfirmModalProps = {
   buttonText: string;
   onClose: () => void;
   onConfirm: () => void;
+  destructive?: boolean;
 };
 
 export function ConfirmModal({
@@ -16,6 +17,7 @@ export function ConfirmModal({
   buttonText,
   onClose,
   onConfirm,
+  destructive = false,
 }: ConfirmModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -39,7 +41,12 @@ export function ConfirmModal({
             <Button variant="outline" onClick={onClose}>
               취소
             </Button>
-            <Button onClick={onConfirm}>{buttonText}</Button>
+            <Button
+              onClick={onConfirm}
+              variant={destructive ? 'destructive' : 'primary'}
+            >
+              {buttonText}
+            </Button>
           </div>
         </div>
       </div>

--- a/src/features/project/components/edit-form/DeleteProjectModalContent.tsx
+++ b/src/features/project/components/edit-form/DeleteProjectModalContent.tsx
@@ -1,0 +1,37 @@
+import { ConfirmModal, ModalPortal } from '@/components';
+import { WarningIcon } from '@/components/icons';
+import { useDeleteProject } from '../../hooks';
+
+type DeleteProjectModalContentProps = {
+  projectId: number;
+  onClose: () => void;
+};
+
+export function DeleteProjectModalContent({
+  projectId,
+  onClose,
+}: DeleteProjectModalContentProps) {
+  const { mutate: deleteProject } = useDeleteProject();
+
+  const handleDeleteProject = () => {
+    deleteProject(projectId);
+  };
+  return (
+    <ModalPortal>
+      <ConfirmModal
+        buttonText="삭제"
+        onClose={onClose}
+        onConfirm={handleDeleteProject}
+        destructive
+      >
+        <WarningIcon width={40} height={40} />
+        <div className="flex flex-col items-center gap-2 mb-6">
+          <h2 className="text-lg font-semibold">
+            정말 프로젝트를 삭제하시겠습니까?
+          </h2>
+          <p>삭제한 프로젝트는 복구할 수 없습니다.</p>
+        </div>
+      </ConfirmModal>
+    </ModalPortal>
+  );
+}

--- a/src/features/project/components/edit-form/EditForm.tsx
+++ b/src/features/project/components/edit-form/EditForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../schemas';
 import { ImageUploader } from '../image-uploader';
 import { TagInput } from '../tag';
+import { DeleteProjectModalContent } from './DeleteProjectModalContent';
 
 type EditFormProps = {
   project: ProjectDetail;
@@ -35,7 +36,9 @@ export function EditForm({ project }: EditFormProps) {
     tags,
   } = project;
   const router = useRouter();
+
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const auth = useAtomValue(authAtom);
 
@@ -156,6 +159,21 @@ export function EditForm({ project }: EditFormProps) {
         <Button type="submit" className="mt-3" isLoading={isSubmitting}>
           수정하기
         </Button>
+        <div className="flex justify-center mt-3">
+          <button
+            type="button"
+            className="cursor-pointer text-sm text-grey hover:text-red-500 hover:underline"
+            onClick={() => setIsDeleteModalOpen(true)}
+          >
+            삭제하기
+          </button>
+          {isDeleteModalOpen && (
+            <DeleteProjectModalContent
+              projectId={id}
+              onClose={() => setIsDeleteModalOpen(false)}
+            />
+          )}
+        </div>
       </form>
     </FormProvider>
   );

--- a/src/features/project/components/edit-form/index.ts
+++ b/src/features/project/components/edit-form/index.ts
@@ -1,0 +1,1 @@
+export * from './EditForm';

--- a/src/features/project/components/image-uploader/ImageUploader.tsx
+++ b/src/features/project/components/image-uploader/ImageUploader.tsx
@@ -1,23 +1,26 @@
 'use client';
 
 import { useImageUploader } from '../../hooks';
+import { EditProjectFormImage } from '../../schemas';
 import { ImageList } from './ImageList';
 import { UploadBox } from './UploadBox';
 
+export type FormImageType = File | EditProjectFormImage;
+
 type ImageUploaderProps = {
   name: string;
-  value: File[];
-  onChange: (files: File[]) => void;
   maxImages?: number;
   disabled?: boolean;
+  value: FormImageType[];
+  onChange: (files: FormImageType[]) => void;
 };
 
 export function ImageUploader({
   name,
-  value,
-  onChange,
   maxImages = 5,
   disabled,
+  value,
+  onChange,
 }: ImageUploaderProps) {
   const {
     fileInputRef,

--- a/src/features/project/components/index.ts
+++ b/src/features/project/components/index.ts
@@ -1,6 +1,7 @@
 export * from './card-item';
 export * from './card-list';
 export * from './create-form';
+export * from './edit-form';
 export * from './image-uploader';
 export * from './latest-projects';
 export * from './project-detail-container';

--- a/src/features/project/hooks/index.ts
+++ b/src/features/project/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useCheckProjectExists';
 export * from './useCreateProject';
+export * from './useEditProject';
 export * from './useGivePumati';
 export * from './useImageUploader';
 export * from './useProjects';

--- a/src/features/project/hooks/index.ts
+++ b/src/features/project/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useCheckProjectExists';
 export * from './useCreateProject';
+export * from './useDeleteProject';
 export * from './useEditProject';
 export * from './useGivePumati';
 export * from './useImageUploader';

--- a/src/features/project/hooks/useDeleteProject.tsx
+++ b/src/features/project/hooks/useDeleteProject.tsx
@@ -1,0 +1,24 @@
+import { PROJECT_PATH } from '@/constants';
+import { accessTokenAtom } from '@/store';
+import { useMutation } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
+import { useRouter } from 'next/navigation';
+import { deleteProject } from '../services';
+
+export function useDeleteProject() {
+  const router = useRouter();
+
+  const accessToken = useAtomValue(accessTokenAtom);
+
+  return useMutation({
+    mutationFn: (projectId: number) =>
+      deleteProject(projectId, accessToken as string),
+    onSuccess: () => {
+      router.push(PROJECT_PATH.ROOT);
+    },
+    onError: (error) => {
+      console.error(error);
+      alert('프로젝트 삭제에 실패했습니다. 잠시후 다시 시도해주세요.');
+    },
+  });
+}

--- a/src/features/project/hooks/useEditProject.tsx
+++ b/src/features/project/hooks/useEditProject.tsx
@@ -1,0 +1,18 @@
+import { accessTokenAtom } from '@/store';
+import { useMutation } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
+import { NewProject } from '../schemas';
+import { editProject } from '../services';
+
+export function useEditProject(projectId: number) {
+  const accessToken = useAtomValue(accessTokenAtom);
+
+  return useMutation({
+    mutationFn: (data: NewProject) =>
+      editProject(projectId, data, accessToken as string),
+    onError: (error) => {
+      console.error(error);
+      alert('프로젝트 수정에 실패했습니다. 잠시후 다시 시도해주세요.');
+    },
+  });
+}

--- a/src/features/project/hooks/useImageUploader.tsx
+++ b/src/features/project/hooks/useImageUploader.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { FormImageType } from '../components/image-uploader/ImageUploader';
 
-export function useImageUploader(
-  value: File[],
-  onChange: (files: File[]) => void,
+export function useImageUploader<T extends FormImageType>(
+  value: T[],
+  onChange: (files: T[]) => void,
   maxImages: number,
 ) {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -20,9 +21,8 @@ export function useImageUploader(
     const files = e.target.files;
     if (!files) return;
 
-    const newFiles = Array.from(files);
+    const newFiles = Array.from(files).map((file) => ({ file })) as T[];
     const currentFiles = [...value];
-
     const combinedFiles = [...currentFiles, ...newFiles].slice(0, maxImages);
 
     onChange(combinedFiles);
@@ -40,7 +40,12 @@ export function useImageUploader(
 
   // URL 해제에 대한 최적화 필요
   useEffect(() => {
-    const newPreviews = value.map((file) => URL.createObjectURL(file));
+    const newPreviews = value.map((item) => {
+      if (item instanceof File) {
+        return URL.createObjectURL(item);
+      }
+      return item.url || URL.createObjectURL(item.file!);
+    });
     setPreviews(newPreviews);
 
     return () => {

--- a/src/features/project/schemas/new-project.ts
+++ b/src/features/project/schemas/new-project.ts
@@ -35,16 +35,18 @@ export const newProjectFormSchema = z.object({
     .max(200, '링크는 200자 이내로 입력해주세요.'),
   images: z
     .array(
-      z
-        .instanceof(File)
-        .refine(
-          (file) => file.size <= MAX_FILE_SIZE,
-          '이미지 용량은 최대 10MB 까지 가능합니다.',
-        )
-        .refine(
-          (file) => ACCEPTED_IMAGE_TYPES.includes(file.type),
-          '지원하지 않는 이미지 형식입니다.',
-        ),
+      z.object({
+        file: z
+          .instanceof(File)
+          .refine(
+            (file) => file.size <= MAX_FILE_SIZE,
+            '이미지 용량은 최대 10MB 까지 가능합니다.',
+          )
+          .refine(
+            (file) => ACCEPTED_IMAGE_TYPES.includes(file.type),
+            '지원하지 않는 이미지 형식입니다.',
+          ),
+      }),
     )
     .min(1, '프로젝트 이미지를 1장 이상 업로드해 주세요.')
     .max(5, '프로젝트 이미지는 최대 5장까지 업로드 가능합니다.'),
@@ -56,6 +58,37 @@ export const newProjectFormSchema = z.object({
 });
 
 export type NewProjectForm = z.infer<typeof newProjectFormSchema>;
+
+const editProjectFormImageSchema = z
+  .object({
+    url: z.string().url().optional(),
+    file: z
+      .instanceof(File)
+      .refine(
+        (file) => file.size <= MAX_FILE_SIZE,
+        '이미지 용량은 최대 10MB 까지 가능합니다.',
+      )
+      .refine(
+        (file) => ACCEPTED_IMAGE_TYPES.includes(file.type),
+        '지원하지 않는 이미지 형식입니다.',
+      )
+      .optional(),
+  })
+  .refine(
+    (data) => data.url || data.file,
+    '이미지 URL 또는 파일이 필요합니다.',
+  );
+
+export type EditProjectFormImage = z.infer<typeof editProjectFormImageSchema>;
+
+export const editProjectFormSchema = newProjectFormSchema.extend({
+  images: z
+    .array(editProjectFormImageSchema)
+    .min(1, '프로젝트 이미지를 1장 이상 업로드해 주세요.')
+    .max(5, '프로젝트 이미지는 최대 5장까지 업로드 가능합니다.'),
+});
+
+export type EditProjectForm = z.infer<typeof editProjectFormSchema>;
 
 const projectImageSchema = z.object({
   url: z.string().url(),

--- a/src/features/project/services/index.ts
+++ b/src/features/project/services/index.ts
@@ -60,6 +60,37 @@ export const createProject = async (
   }
 };
 
+export const editProject = async (
+  projectId: number,
+  projectData: NewProject,
+  accessToken: string,
+) => {
+  try {
+    const response = await fetch(`${BASE_URL}/api/projects/${projectId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(projectData),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    return data.data;
+  } catch (error) {
+    console.error('Failed to edit project:', error);
+
+    throw error instanceof Error
+      ? error
+      : new Error('An unexpected error occurred while editing a project');
+  }
+};
+
 export const getProject = async (projectId: number) => {
   if (typeof projectId !== 'number' || isNaN(projectId)) return undefined;
 

--- a/src/features/project/services/index.ts
+++ b/src/features/project/services/index.ts
@@ -91,6 +91,31 @@ export const editProject = async (
   }
 };
 
+export const deleteProject = async (projectId: number, token: string) => {
+  try {
+    const response = await fetch(`${BASE_URL}/api/projects/${projectId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    return data.data;
+  } catch (error) {
+    console.error('Failed to delete project:', error);
+
+    throw error instanceof Error
+      ? error
+      : new Error('An unexpected error occurred while deleting a project');
+  }
+};
+
 export const getProject = async (projectId: number) => {
   if (typeof projectId !== 'number' || isNaN(projectId)) return undefined;
 


### PR DESCRIPTION
## ⭐Key Changes

프로젝트 수정 및 삭제 기능을 구현했습니다.

1. 기존 `<ImageUploader>` 컴포넌트를 재사용하기 위해 입력폼의 `images` 타입을 변경했습니다. 수정페이지의 경우 프로젝트 상세 정보를 받아와 기본값으로 설정해줘야 하는데, 받아오는 데이터의 타입이 `<ImageUploader>` 컴포넌트의 타입과 일치하지 않아 타입을 좀 더 확장하였습니다. 원래 `images: File[]`이었지만, `images: (File | { url?: string; file?: File })[]`으로 확장하여 받아온 데이터와 추가된 데이터 모두 적용되는 `FormImageType`을 만들었습니다.
2. 프로젝트 삭제 기능을 구현했습니다. "삭제하기" 버튼 클릭 시 확인 모달이 열리며, 한 번 더 "삭제" 버튼을 클릭하면 프로젝트 삭제 후 프로젝트 목록 페이지로 이동됩니다.

<br />

## 🖐️To reviewers

1. 타입을 확장하는 방법으로 구현하긴했지만, 처음 폼 입력값을 관리할 때부터 url로 변경하여 관리하는 방법으로 추후 리팩토링할 예정입니다.

<br />

## 📌 issue

close #77 #78 
