### PR TITLE
프로젝트 생성 이미지 유효성검사

### DIFF
--- a/src/app/(header)/projects/[id]/edit/page.tsx
+++ b/src/app/(header)/projects/[id]/edit/page.tsx
@@ -17,7 +17,7 @@ export default async function ProjectEditPage({
   }
   return (
     <section className="flex flex-col items-center min-h-[calc(100vh-6rem)]">
-      <h1 className="text-xl font-semibold mt-9">프로젝트 생성</h1>
+      <h1 className="text-xl font-semibold mt-9">프로젝트 수정</h1>
       <EditForm project={project} />
     </section>
   );

--- a/src/features/project/components/image-uploader/ImageUploader.tsx
+++ b/src/features/project/components/image-uploader/ImageUploader.tsx
@@ -33,7 +33,7 @@ export function ImageUploader({
   return (
     <div className="flex flex-col gap-2">
       <p className="text-grey text-sm absolute top-9 left-0">
-        * 첫 번째 이미지가 대표 이미지로 설정됩니다. (최대 5장)
+        * PNG, JPG, JPEG 형식, 최대 10MB, 최대 5장
       </p>
       <UploadBox
         onClick={handleFileInputClick}

--- a/src/features/project/schemas/new-project.ts
+++ b/src/features/project/schemas/new-project.ts
@@ -10,6 +10,19 @@ export const tagSchema = z
     message: '태그는 특수문자를 포함할 수 없습니다.',
   });
 
+export const imageSchema = z.object({
+  file: z
+    .instanceof(File, { message: '이미지를 업로드해 주세요.' })
+    .refine(
+      (file) => file.size <= MAX_FILE_SIZE,
+      '이미지 용량은 최대 10MB 까지 가능합니다.',
+    )
+    .refine(
+      (file) => ACCEPTED_IMAGE_TYPES.includes(file.type),
+      '지원하지 않는 이미지 형식입니다.',
+    ),
+});
+
 export const newProjectFormSchema = z.object({
   title: z
     .string()
@@ -37,15 +50,13 @@ export const newProjectFormSchema = z.object({
     .array(
       z.object({
         file: z
-          .instanceof(File)
-          .refine(
-            (file) => file.size <= MAX_FILE_SIZE,
-            '이미지 용량은 최대 10MB 까지 가능합니다.',
-          )
-          .refine(
-            (file) => ACCEPTED_IMAGE_TYPES.includes(file.type),
-            '지원하지 않는 이미지 형식입니다.',
-          ),
+          .instanceof(File, { message: '이미지를 업로드해 주세요.' })
+          .refine((file) => file.size <= MAX_FILE_SIZE, {
+            message: '이미지 용량은 최대 10MB 까지 가능합니다.',
+          })
+          .refine((file) => ACCEPTED_IMAGE_TYPES.includes(file.type), {
+            message: '지원하지 않는 이미지 형식입니다.',
+          }),
       }),
     )
     .min(1, '프로젝트 이미지를 1장 이상 업로드해 주세요.')


### PR DESCRIPTION
## ⭐Key Changes

프로젝트 생성 시 zod를 통해 유효성 검사는 진행해서 통과하지 못하는 경우 생성 요청 자체를 막았는데, `helper text`가 아무것도 뜨지 않은 상태에서 “생성하기” 버튼을 클릭해도 생성이 안된다는 피드백을 받았습니다.

각 파일에 대한 유효성 검증은 진행하지만 이를 기반으로 전체 `images`에 대한 유효성 검증이 이루어지지 않아서, 이미지 입력폼에 대한 유효성에는 에러가 없지만 각 파일에서 에러가 있는 경우 이런 상황이 발생했습니다.

따라서 이미지가 추가되는 경우 각 이미지의 에러 여부를 확인하고, 에러가 있는 경우 이미지 추가를 막고 에러 텍스트를 보여주는 방법으로 수정했습니다.

<br />

## 🖐️To reviewers

1. 만약 한번에 여러 이미지를 업로드했는데 하나의 이미지라도 유효성 검사를 통과하지 못하는 경우 해당 동작에서의 모든 이미지는 업로드되지 않고, 첫 번째 에러 메세지를 `helper text`로 보여줍니다.

<br />

## 📌 issue

close #97 
