### PR TITLE
링크 공유 시 이미지 나타나지 않는 문제 해결

### DIFF
--- a/src/constants/metadata.ts
+++ b/src/constants/metadata.ts
@@ -21,6 +21,7 @@ export const METADATA = Object.freeze({
       '프로젝트 포트폴리오',
       '프로젝트 탐색',
     ].join(', '),
+    metadataBase: new URL(BASE_URL!),
     openGraph: {
       title: {
         default: '품앗이',


### PR DESCRIPTION
- 이미지 주소 metadataBase 사용

## ⭐Key Changes

1. 링크 공유 시 이미지가 나타나지 않는 문제를 해결했습니다.

<br />

## 🖐️To reviewers

1. 이미지 주소를 상대경로로 설정하여 나타나는 문제였고, `metadataBase`를 설정하여 해결했습니다.
