### PR TITLE
S3버킷 주소변경

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 's3-pumati-test.s3.ap-northeast-2.amazonaws.com',
+        hostname: 's3-pumati-prod.s3.ap-northeast-2.amazonaws.com',
       },
     ],
   },

--- a/src/features/user/components/attendance/Attendance.tsx
+++ b/src/features/user/components/attendance/Attendance.tsx
@@ -30,8 +30,8 @@ export function Attendance() {
     }
 
     setIsAttendanceModalOpen(true);
-    const { devLuckDTO } = await checkAttendance(accessToken);
-    setLuckMessage(devLuckDTO.overall);
+    const { devLuck } = await checkAttendance(accessToken);
+    setLuckMessage(devLuck.overall);
   };
   return (
     <article className="flex flex-col items-center justify-center gap-4 p-8 my-10 bg-blue-white">

--- a/src/features/user/schemas/attendance.ts
+++ b/src/features/user/schemas/attendance.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const attendanceSchema = z.object({
   id: z.number(),
-  devLuckDTO: z.object({
+  devLuck: z.object({
     overall: z.string(),
   }),
   checkedAt: z.string(),


### PR DESCRIPTION
## ⭐Key Changes

1. S3 버킷 변경(test -> prod)을 위해 `remotePatterns` 주소를 변경했습니다.
2. 백엔드 DTO 필드명 변경으로 인해 프론트 response 스키마 필드명을 변경했습니다.

