### PR TITLE
프로젝트 목록 페이지 무한스크롤 안되는 문제 해결

### DIFF
--- a/src/features/project/components/card-list/CardList.tsx
+++ b/src/features/project/components/card-list/CardList.tsx
@@ -12,13 +12,8 @@ type CardListProps = {
 
 export function CardList({ ref, isFetchingNextPage, projects }: CardListProps) {
   return (
-    <article className="w-full">
-      <ul
-        className={cn(
-          'flex flex-col gap-5',
-          isFetchingNextPage ? 'mb-8' : 'mb-20',
-        )}
-      >
+    <article className={cn('w-full', isFetchingNextPage ? 'pb-8' : 'pb-20')}>
+      <ul className="flex flex-col gap-5 mb-4">
         {projects.map((project) => (
           <CardItem key={project.id} project={project} />
         ))}


### PR DESCRIPTION
## ⭐Key Changes

1. ul 태그 아래에 observer를 두고, 해당 요소가 화면에 나오면 다음 페이지를 요청하는 로직으로 구현하였습니다. 그런데 ul 태그의 margin-bottom 때문에 observer가 인식되지 않아 다음 페이지 요청이 가지 않았고, margin-bottom을 상위 컨데이터 요소로 옮겨서 해결했습니다.

