### PR TITLE
배포 2주차 피드백 반영

### DIFF
--- a/src/features/project/components/card-item/CardItem.tsx
+++ b/src/features/project/components/card-item/CardItem.tsx
@@ -11,7 +11,7 @@ type CardItemProps = {
 };
 
 export function CardItem({ project }: CardItemProps) {
-  const { id, representativeImageUrl, title, introduction, term, tags } =
+  const { id, representativeImageUrl, title, introduction, tags, teamNumber } =
     project;
   const router = useRouter();
 
@@ -35,7 +35,9 @@ export function CardItem({ project }: CardItemProps) {
       <div className="px-4 pt-2 pb-4">
         <div className="flex justify-between items-baseline">
           <h3 className="font-bold text-lg truncate">{title}</h3>
-          <p className="ml-4 text-sm text-dark-grey shrink-0">판교{term}기</p>
+          <p className="ml-4 text-dark-grey text-sm font-semibold shrink-0">
+            {teamNumber}팀
+          </p>
         </div>
         <p className="mt-1 text-sm xs:text-[15px] text-dark-grey line-clamp-2 whitespace-pre-wrap break-words">
           {introduction}

--- a/src/features/project/components/index.ts
+++ b/src/features/project/components/index.ts
@@ -11,4 +11,5 @@ export * from './projects-container';
 export * from './ranked-projects';
 export * from './simple-card-item';
 export * from './simple-card-list';
+export * from './simple-projects';
 export * from './tag';

--- a/src/features/project/components/latest-projects/LatestProjects.tsx
+++ b/src/features/project/components/latest-projects/LatestProjects.tsx
@@ -2,7 +2,7 @@ import { getLatestProjects } from '../../services';
 import { ProjectGallery } from '../project-gallery';
 
 export async function LatestProjects() {
-  const { data: projects } = await getLatestProjects(null, 0, 5);
+  const { data: projects } = await getLatestProjects(null, 0);
 
   return <ProjectGallery projects={projects} />;
 }

--- a/src/features/project/components/project-detail-container/Description.tsx
+++ b/src/features/project/components/project-detail-container/Description.tsx
@@ -3,7 +3,6 @@
 import { Button } from '@/components';
 import { EditIcon } from '@/components/icons';
 import { accessTokenAtom, authAtom } from '@/store';
-import { dateYYYYMMDD } from '@/utils/date';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { useGivePumati, useReceivePumati } from '../../hooks';
@@ -14,6 +13,7 @@ type DescriptionProps = Pick<
   ProjectDetail,
   | 'id'
   | 'teamId'
+  | 'teamNumber'
   | 'title'
   | 'modifiedAt'
   | 'term'
@@ -26,6 +26,7 @@ type DescriptionProps = Pick<
 export function Description({
   id,
   teamId,
+  teamNumber,
   title,
   modifiedAt,
   term,
@@ -68,8 +69,10 @@ export function Description({
         <div className="flex items-start justify-between">
           <h1 className="text-2xl font-bold mr-2">{title}</h1>
           <div className="flex flex-col items-end">
-            <p className="text-sm text-grey">{dateYYYYMMDD(modifiedAt)}</p>
-            <p className="text-sm text-dark-grey">판교{term}기</p>
+            <p className="text-sm text-dark-grey font-semibold">
+              {teamNumber}팀
+            </p>
+            <p className="text-sm text-grey">판교{term}기</p>
           </div>
         </div>
       </div>

--- a/src/features/project/components/project-detail-container/ProjectDetailContainer.tsx
+++ b/src/features/project/components/project-detail-container/ProjectDetailContainer.tsx
@@ -20,6 +20,7 @@ export function ProjectDetailContainer({
     modifiedAt,
     term,
     teamId,
+    teamNumber,
     introduction,
     deploymentUrl,
     detailedDescription,
@@ -52,6 +53,7 @@ export function ProjectDetailContainer({
         <Description
           id={id}
           teamId={teamId}
+          teamNumber={teamNumber}
           title={title}
           modifiedAt={modifiedAt}
           term={term}

--- a/src/features/project/components/project-gallery/ProjectGallery.tsx
+++ b/src/features/project/components/project-gallery/ProjectGallery.tsx
@@ -1,8 +1,3 @@
-'use client';
-
-import { Button } from '@/components';
-import { PROJECT_PATH } from '@/constants';
-import { useRouter } from 'next/navigation';
 import { ProjectItem } from '../../schemas';
 import { CardItem } from '../card-item';
 import { Carousel } from '../carousel';
@@ -12,11 +7,6 @@ type ProjectGalleryProps = {
 };
 
 export function ProjectGallery({ projects }: ProjectGalleryProps) {
-  const router = useRouter();
-
-  const handleBrowseProjectsClick = () => {
-    router.push(PROJECT_PATH.ROOT);
-  };
   return (
     <section className="flex flex-col gap-4 mx-auto my-10 max-w-[25rem] w-full">
       <div className="text-center">
@@ -32,7 +22,6 @@ export function ProjectGallery({ projects }: ProjectGalleryProps) {
           ))}
         </Carousel>
       </div>
-      <Button onClick={handleBrowseProjectsClick}>프로젝트 둘러보기</Button>
     </section>
   );
 }

--- a/src/features/project/components/ranked-projects/RankedProjects.tsx
+++ b/src/features/project/components/ranked-projects/RankedProjects.tsx
@@ -1,10 +1,10 @@
 import { getRankedProjects, getSnapshot } from '../../services';
-import { SimpleCardList } from '../simple-card-list';
+import { SimpleProjects } from '../simple-projects';
 
 export async function RankedProjects() {
   const { id } = await getSnapshot();
 
   const { data: projects } = await getRankedProjects(id, 0, 3);
 
-  return <SimpleCardList projects={projects} />;
+  return <SimpleProjects projects={projects} />;
 }

--- a/src/features/project/components/simple-card-list/SimpleCardList.tsx
+++ b/src/features/project/components/simple-card-list/SimpleCardList.tsx
@@ -7,21 +7,10 @@ type SimpleCardListProps = {
 
 export function SimpleCardList({ projects }: SimpleCardListProps) {
   return (
-    <article className="w-full max-w-[25rem] mx-auto my-10">
-      <div className="flex flex-col gap-2 mb-8 text-center">
-        <h2 className="text-2xl font-bold">
-          품앗이 상위 <span className="text-blue">TOP3</span> 프로젝트
-        </h2>
-        <p className="font-medium text-dark-grey">
-          지금 커뮤니티에서 <br />
-          가장 활발한 프로젝트들을 소개할게요!
-        </p>
-      </div>
-      <ul className="flex flex-col gap-5">
-        {projects.map((project, index) => (
-          <SimpleCardItem key={project.id} project={project} rank={index + 1} />
-        ))}
-      </ul>
-    </article>
+    <ul className="flex flex-col gap-5">
+      {projects.map((project, index) => (
+        <SimpleCardItem key={project.id} project={project} rank={index + 1} />
+      ))}
+    </ul>
   );
 }

--- a/src/features/project/components/simple-projects/SimpleProjects.tsx
+++ b/src/features/project/components/simple-projects/SimpleProjects.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { CallToAction } from '@/components';
+import { PROJECT_PATH } from '@/constants';
+import { useRouter } from 'next/navigation';
+import { ProjectItem } from '../../schemas';
+import { SimpleCardList } from '../simple-card-list/SimpleCardList';
+
+type SimpleCardListProps = {
+  projects: ProjectItem[];
+};
+
+export function SimpleProjects({ projects }: SimpleCardListProps) {
+  const router = useRouter();
+
+  const handleBrowseProjectsClick = () => {
+    router.push(PROJECT_PATH.ROOT);
+  };
+  return (
+    <article className="w-full max-w-[25rem] mx-auto my-10">
+      <div className="flex flex-col gap-2 mb-6 text-center">
+        <h2 className="text-2xl font-bold">
+          품앗이 상위 <span className="text-blue">TOP3</span> 프로젝트
+        </h2>
+        <p className="font-medium text-dark-grey mb-4">
+          지금 커뮤니티에서 <br />
+          가장 활발한 프로젝트들을 소개할게요!
+        </p>
+        <CallToAction
+          text="더 많은 프로젝트 보기"
+          buttonText="둘러보기"
+          action={handleBrowseProjectsClick}
+        />
+      </div>
+      <SimpleCardList projects={projects} />
+    </article>
+  );
+}

--- a/src/features/project/components/simple-projects/SimpleProjects.tsx
+++ b/src/features/project/components/simple-projects/SimpleProjects.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CallToAction } from '@/components';
+import { Button } from '@/components';
 import { PROJECT_PATH } from '@/constants';
 import { useRouter } from 'next/navigation';
 import { ProjectItem } from '../../schemas';
@@ -18,7 +18,7 @@ export function SimpleProjects({ projects }: SimpleCardListProps) {
   };
   return (
     <article className="w-full max-w-[25rem] mx-auto my-10">
-      <div className="flex flex-col gap-2 mb-6 text-center">
+      <div className="flex flex-col gap-2 mb-4 text-center">
         <h2 className="text-2xl font-bold">
           품앗이 상위 <span className="text-blue">TOP3</span> 프로젝트
         </h2>
@@ -26,13 +26,15 @@ export function SimpleProjects({ projects }: SimpleCardListProps) {
           지금 커뮤니티에서 <br />
           가장 활발한 프로젝트들을 소개할게요!
         </p>
-        <CallToAction
-          text="더 많은 프로젝트 보기"
-          buttonText="둘러보기"
-          action={handleBrowseProjectsClick}
-        />
       </div>
       <SimpleCardList projects={projects} />
+      <Button
+        className="mt-6"
+        type="button"
+        onClick={handleBrowseProjectsClick}
+      >
+        프로젝트 둘러보기
+      </Button>
     </article>
   );
 }

--- a/src/features/project/components/simple-projects/index.ts
+++ b/src/features/project/components/simple-projects/index.ts
@@ -1,0 +1,1 @@
+export * from './SimpleProjects';

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,9 +1,13 @@
-import { formatDate, formatDistanceToNow } from 'date-fns';
+import { addHours, formatDate, formatDistanceToNow } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
 export const dateYYYYMMDD = (date: string) => formatDate(date, 'yyyy.MM.dd');
 
-export const dateDistance = (date: string) =>
-  formatDistanceToNow(new Date(date), {
+export const dateDistance = (date: string) => {
+  const distance = formatDistanceToNow(addHours(new Date(date), 9), {
     locale: ko,
+    addSuffix: true,
   });
+
+  return distance.includes('1분 미만') ? '방금 전' : distance;
+};


### PR DESCRIPTION
## ⭐Key Changes

배포 2주차 피드백을 반영했습니다.

1. 프로젝트 둘러보기 버튼 상단으로 위치 변경
2. 프로젝트 카드에 몇팀인지 정보 추가
3. 댓글 시간 한국시간으로 변경

<br />

## 🖐️To reviewers

1. 둘러보기 버튼을 상단으로 옮기고, 기존에 하단에 있던 버튼은 삭제했습니다. 대신 하단의 최신 프로젝트 목록 데이터 개수를 5개에서 10개로 늘려 루트페이지에서 더 많은 프로젝트를 볼 수 있게 수정했습니다.
2. 댓글 시간이 1분 미만인 경우 "방금 전"으로 표기했습니다.

<br />

## 📌 issue

close #121 
