### PR TITLE
마이페이지 조회 기능 구현

### DIFF
--- a/src/app/(header)/mypage/layout.tsx
+++ b/src/app/(header)/mypage/layout.tsx
@@ -1,0 +1,23 @@
+import { ROOT_PATH } from '@/constants';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+export default async function MyPageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get('refreshToken')?.value;
+
+  if (!refreshToken) {
+    redirect(ROOT_PATH);
+  }
+  return (
+    <section className="flex justify-center">
+      <div className="flex flex-col items-center gap-4 w-full max-w-[25rem]">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/app/(header)/mypage/page.tsx
+++ b/src/app/(header)/mypage/page.tsx
@@ -1,25 +1,5 @@
 import { Dashboard, Information } from '@/features/user/components';
-import { AuthData, Team } from '@/features/user/schemas';
-
-const MY_DATA: AuthData = {
-  id: 1,
-  teamId: 8,
-  teamNumber: 8,
-  term: 2,
-  email: 'jay@kakao.com',
-  isSocial: true,
-  name: '권덕재',
-  nickname: 'jay',
-  course: 'FULL_STACK',
-  profileImageUrl:
-    'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/94cc479c-b871-430f-8a49-c1625b761a7c.jpeg',
-  role: 'TRAINEE',
-  emailOptInAt: '2025-03-12T00:00:00Z',
-  emailOptOutAt: null,
-  state: 'ACTIVE',
-  createdAt: '2025-03-12T00:00:00Z',
-  modifiedAt: '2025-03-12T00:00:00Z',
-};
+import { Team } from '@/features/user/schemas';
 
 const DASHBOARD: Team = {
   id: 1,
@@ -39,7 +19,7 @@ export default async function MyPage() {
   return (
     <>
       <h1 className="text-xl font-semibold my-9">마이페이지</h1>
-      <Information user={MY_DATA} />
+      <Information />
       <Dashboard dashboard={DASHBOARD} />
     </>
   );

--- a/src/app/(header)/mypage/page.tsx
+++ b/src/app/(header)/mypage/page.tsx
@@ -1,26 +1,13 @@
-import { Dashboard, Information } from '@/features/user/components';
-import { Team } from '@/features/user/schemas';
-
-const DASHBOARD: Team = {
-  id: 1,
-  term: 2,
-  number: 8,
-  projectId: 1,
-  rank: 1,
-  givedPumatiCount: 300,
-  receivedPumatiCount: 300,
-  badgeImageUrl:
-    'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/94cc479c-b871-430f-8a49-c1625b761a7c.jpeg',
-  createdAt: '2025-03-12T00:00:00Z',
-  modifiedAt: '2025-03-12T00:00:00Z',
-};
+import { DashboardFetcher, Information } from '@/features/user/components';
 
 export default async function MyPage() {
   return (
     <>
       <h1 className="text-xl font-semibold my-9">마이페이지</h1>
       <Information />
-      <Dashboard dashboard={DASHBOARD} />
+      <div className="mb-12 w-full">
+        <DashboardFetcher />
+      </div>
     </>
   );
 }

--- a/src/app/(header)/mypage/page.tsx
+++ b/src/app/(header)/mypage/page.tsx
@@ -1,0 +1,46 @@
+import { Dashboard, Information } from '@/features/user/components';
+import { AuthData, Team } from '@/features/user/schemas';
+
+const MY_DATA: AuthData = {
+  id: 1,
+  teamId: 8,
+  teamNumber: 8,
+  term: 2,
+  email: 'jay@kakao.com',
+  isSocial: true,
+  name: '권덕재',
+  nickname: 'jay',
+  course: 'FULL_STACK',
+  profileImageUrl:
+    'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/94cc479c-b871-430f-8a49-c1625b761a7c.jpeg',
+  role: 'TRAINEE',
+  emailOptInAt: '2025-03-12T00:00:00Z',
+  emailOptOutAt: null,
+  state: 'ACTIVE',
+  createdAt: '2025-03-12T00:00:00Z',
+  modifiedAt: '2025-03-12T00:00:00Z',
+};
+
+const DASHBOARD: Team = {
+  id: 1,
+  term: 2,
+  number: 8,
+  projectId: 1,
+  rank: 1,
+  givedPumatiCount: 300,
+  receivedPumatiCount: 300,
+  badgeImageUrl:
+    'https://s3-pumati-test.s3.ap-northeast-2.amazonaws.com/uploads/94cc479c-b871-430f-8a49-c1625b761a7c.jpeg',
+  createdAt: '2025-03-12T00:00:00Z',
+  modifiedAt: '2025-03-12T00:00:00Z',
+};
+
+export default async function MyPage() {
+  return (
+    <>
+      <h1 className="text-xl font-semibold my-9">마이페이지</h1>
+      <Information user={MY_DATA} />
+      <Dashboard dashboard={DASHBOARD} />
+    </>
+  );
+}

--- a/src/app/(header)/projects/[id]/page.tsx
+++ b/src/app/(header)/projects/[id]/page.tsx
@@ -44,7 +44,6 @@ export default async function ProjectDetailPage({
   return (
     <section className="pb-25">
       <Suspense fallback={<ProjectDetailFallback />}>
-        {/* <ProjectDetailFallback /> */}
         <ProjectDetailFetcher id={id} />
       </Suspense>
     </section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,8 @@
   /* Secondary Colors */
   --color-green: #a3d139;
   --color-light-green: #fafdf5;
+  --color-mint: #3dc2bb;
+  --color-light-mint: #f5fcfb;
   --color-red: #e53935;
   --color-light-red: #fff9f8;
 

--- a/src/components/header/NavBar.tsx
+++ b/src/components/header/NavBar.tsx
@@ -1,4 +1,4 @@
-import { AUTH_PATH, PROJECT_PATH, ROOT_PATH } from '@/constants';
+import { AUTH_PATH, PROJECT_PATH, ROOT_PATH, USER_PATH } from '@/constants';
 import { useLogout } from '@/features/auth/hooks';
 import { useOutsideClick } from '@/hooks';
 import { isLoggedInAtom, navbarAtom } from '@/store';
@@ -29,6 +29,10 @@ export function NavBar({ triggerRef }: NavbarProps) {
     {
       label: '프로젝트',
       href: PROJECT_PATH.ROOT,
+    },
+    {
+      label: '마이페이지',
+      href: USER_PATH.MY_PAGE,
     },
   ];
   const menuHeight = `${1 + 3 * (menuList.length + 1)}rem`;

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -10,3 +10,7 @@ export const PROJECT_PATH = Object.freeze({
   NEW: '/projects/new',
   DETAIL: (id: string) => `/projects/${id}`,
 });
+
+export const USER_PATH = Object.freeze({
+  MY_PAGE: '/mypage',
+});

--- a/src/constants/query-key.ts
+++ b/src/constants/query-key.ts
@@ -5,6 +5,7 @@ export const AUTH_QUERY_KEY = Object.freeze({
 
 export const USER_QUERY_KEY = Object.freeze({
   ATTENDANCE_STATE: ['attendance-state'],
+  DASHBOARD: (teamId: number) => ['dashboard', teamId],
 });
 
 export const PROJECT_QUERY_KEY = Object.freeze({

--- a/src/features/auth/hooks/useAuth.tsx
+++ b/src/features/auth/hooks/useAuth.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MyData } from '@/features/user/schemas';
+import { AuthData } from '@/features/user/schemas';
 import { authAtom } from '@/store/atoms/user';
 import { useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
@@ -9,7 +9,7 @@ import { getMe } from '../services';
 export function useAuth() {
   const setAuth = useSetAtom(authAtom);
 
-  return useMutation<MyData, Error, string>({
+  return useMutation<AuthData, Error, string>({
     mutationFn: getMe,
     onSuccess: ({ id, email, name, profileImageUrl, teamId }) => {
       setAuth({

--- a/src/features/auth/hooks/useAuth.tsx
+++ b/src/features/auth/hooks/useAuth.tsx
@@ -11,15 +11,7 @@ export function useAuth() {
 
   return useMutation<AuthData, Error, string>({
     mutationFn: getMe,
-    onSuccess: ({ id, email, name, profileImageUrl, teamId }) => {
-      setAuth({
-        id,
-        email,
-        name,
-        profileImageUrl,
-        teamId,
-      });
-    },
+    onSuccess: setAuth,
     onError: (error) => {
       console.error(error);
     },

--- a/src/features/auth/schemas/login.ts
+++ b/src/features/auth/schemas/login.ts
@@ -9,7 +9,7 @@ export const authSchema = z.object({
   email: z.string().email(),
   name: z.string(),
   profileImageUrl: z.string().url(),
-  teamId: z.number(),
+  teamId: z.number().nullable(),
 });
 
 export type Auth = z.infer<typeof authSchema>;

--- a/src/features/auth/schemas/login.ts
+++ b/src/features/auth/schemas/login.ts
@@ -3,13 +3,3 @@ import { z } from 'zod';
 export const loginProviderSchema = z.enum(['kakao']);
 
 export type LoginProvider = z.infer<typeof loginProviderSchema>;
-
-export const authSchema = z.object({
-  id: z.number(),
-  email: z.string().email(),
-  name: z.string(),
-  profileImageUrl: z.string().url(),
-  teamId: z.number().nullable(),
-});
-
-export type Auth = z.infer<typeof authSchema>;

--- a/src/features/user/components/dashboard/Dashboard.tsx
+++ b/src/features/user/components/dashboard/Dashboard.tsx
@@ -1,0 +1,83 @@
+import { cn } from '@/utils/style';
+import Image from 'next/image';
+import { Team } from '../../schemas';
+import { DashboardItem } from './DashboardItem';
+
+type DashboardProps = {
+  dashboard: Team;
+};
+
+export function Dashboard({ dashboard }: DashboardProps) {
+  const { badgeImageUrl, givedPumatiCount, receivedPumatiCount, rank } =
+    dashboard;
+
+  const dashboardItems = [
+    {
+      title: '뱃지',
+      item: (
+        <div className="relative h-14 w-14 shrink-0 rounded-full">
+          <Image
+            src={badgeImageUrl}
+            alt="뱃지"
+            fill
+            className="rounded-full object-cover"
+          />
+        </div>
+      ),
+      itemStyle: 'bg-light-blue border-blue',
+    },
+    {
+      title: '품앗이 등수',
+      item: <DashboardItem value={rank} unit="등" textColor="text-green" />,
+      itemStyle: 'bg-light-green border-green',
+    },
+    {
+      title: '준 품앗이',
+      item: (
+        <DashboardItem
+          value={givedPumatiCount}
+          unit="번"
+          textColor="text-mint"
+        />
+      ),
+      itemStyle: 'bg-light-mint border-mint',
+    },
+    {
+      title: '받은 품앗이',
+      item: (
+        <DashboardItem
+          value={receivedPumatiCount}
+          unit="번"
+          textColor="text-red"
+        />
+      ),
+      itemStyle: 'bg-light-red border-red',
+    },
+  ];
+  return (
+    <section className="flex flex-col gap-4 w-full">
+      <div className="flex justify-between items-end">
+        <h2 className="text-lg font-semibold">대시보드</h2>
+        <button className="text-sm text-blue cursor-pointer hover:underline">
+          프로젝트 보러가기
+        </button>
+      </div>
+      <ul className="grid grid-cols-2 gap-2">
+        {dashboardItems.map(({ title, item, itemStyle }) => (
+          <li
+            key={itemStyle}
+            className={cn(
+              'flex flex-col items-center px-4 py-3 border rounded-xl h-28',
+              itemStyle,
+            )}
+          >
+            <p className="self-start font-semibold">{title}</p>
+            <div className="flex justify-center items-center h-full">
+              {item}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/features/user/components/dashboard/Dashboard.tsx
+++ b/src/features/user/components/dashboard/Dashboard.tsx
@@ -55,29 +55,19 @@ export function Dashboard({ dashboard }: DashboardProps) {
     },
   ];
   return (
-    <section className="flex flex-col gap-4 w-full">
-      <div className="flex justify-between items-end">
-        <h2 className="text-lg font-semibold">대시보드</h2>
-        <button className="text-sm text-blue cursor-pointer hover:underline">
-          프로젝트 보러가기
-        </button>
-      </div>
-      <ul className="grid grid-cols-2 gap-2">
-        {dashboardItems.map(({ title, item, itemStyle }) => (
-          <li
-            key={itemStyle}
-            className={cn(
-              'flex flex-col items-center px-4 py-3 border rounded-xl h-28',
-              itemStyle,
-            )}
-          >
-            <p className="self-start font-semibold">{title}</p>
-            <div className="flex justify-center items-center h-full">
-              {item}
-            </div>
-          </li>
-        ))}
-      </ul>
-    </section>
+    <ul className="grid grid-cols-2 gap-2">
+      {dashboardItems.map(({ title, item, itemStyle }) => (
+        <li
+          key={itemStyle}
+          className={cn(
+            'flex flex-col items-center px-4 py-3 border rounded-xl h-28',
+            itemStyle,
+          )}
+        >
+          <p className="self-start font-semibold">{title}</p>
+          <div className="flex justify-center items-center h-full">{item}</div>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/src/features/user/components/dashboard/DashboardFallback.tsx
+++ b/src/features/user/components/dashboard/DashboardFallback.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@/utils/style';
+
+const DASHBOARDITEMS = [
+  {
+    title: '뱃지',
+    itemStyle: 'bg-light-blue border-blue',
+  },
+  {
+    title: '품앗이 등수',
+    itemStyle: 'bg-light-green border-green',
+  },
+  {
+    title: '준 품앗이',
+    itemStyle: 'bg-light-mint border-mint',
+  },
+  {
+    title: '받은 품앗이',
+    itemStyle: 'bg-light-red border-red',
+  },
+];
+
+export function DashboardFallback() {
+  return (
+    <ul className="grid grid-cols-2 gap-2">
+      {DASHBOARDITEMS.map(({ title, itemStyle }) => (
+        <li
+          key={itemStyle}
+          className={cn(
+            'flex flex-col items-center px-4 py-3 border rounded-xl h-28',
+            itemStyle,
+          )}
+        >
+          <p className="self-start font-semibold">{title}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/user/components/dashboard/DashboardFetcher.tsx
+++ b/src/features/user/components/dashboard/DashboardFetcher.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { authAtom } from '@/store';
+import { useAtomValue } from 'jotai';
+import { useDashboard } from '../../hooks';
+import { Dashboard } from './Dashboard';
+import { DashboardFallback } from './DashboardFallback';
+
+export function DashboardFetcher() {
+  const authData = useAtomValue(authAtom);
+  const { data: dashboard, isLoading } = useDashboard(authData?.teamId);
+
+  if (!authData) {
+    // 에러 throw 하고 에러바운더리로 처리
+    return null;
+  }
+  return (
+    <section className="flex flex-col gap-4 w-full">
+      <div className="flex justify-between items-end">
+        <h2 className="text-lg font-semibold">대시보드</h2>
+        <button className="text-sm text-blue cursor-pointer hover:underline">
+          프로젝트 보러가기
+        </button>
+      </div>
+      {isLoading ? <DashboardFallback /> : <Dashboard dashboard={dashboard} />}
+    </section>
+  );
+}

--- a/src/features/user/components/dashboard/DashboardItem.tsx
+++ b/src/features/user/components/dashboard/DashboardItem.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/utils/style';
+
+type DashboardItemProps = {
+  value: number;
+  unit: string;
+  textColor: string;
+};
+
+export function DashboardItem({ value, unit, textColor }: DashboardItemProps) {
+  return (
+    <p className={cn('font-bold text-base xs:text-xl', textColor)}>
+      {value}
+      <span className="text-xs xs:text-sm">{unit}</span>
+    </p>
+  );
+}

--- a/src/features/user/components/dashboard/index.ts
+++ b/src/features/user/components/dashboard/index.ts
@@ -1,0 +1,1 @@
+export * from './Dashboard';

--- a/src/features/user/components/dashboard/index.ts
+++ b/src/features/user/components/dashboard/index.ts
@@ -1,1 +1,2 @@
 export * from './Dashboard';
+export * from './DashboardFetcher';

--- a/src/features/user/components/index.ts
+++ b/src/features/user/components/index.ts
@@ -1,2 +1,3 @@
+export * from './dashboard';
 export * from './image-uploader';
 export * from './information';

--- a/src/features/user/components/index.ts
+++ b/src/features/user/components/index.ts
@@ -1,1 +1,2 @@
 export * from './image-uploader';
+export * from './information';

--- a/src/features/user/components/information/Information.tsx
+++ b/src/features/user/components/information/Information.tsx
@@ -1,16 +1,24 @@
+'use client';
+
 import { ArrowIcon } from '@/components/icons';
+import { COURSE } from '@/constants';
+import { authAtom } from '@/store';
+import { useAtomValue } from 'jotai';
 import Image from 'next/image';
-import { AuthData } from '../../schemas';
 
-type InformationProps = {
-  user: AuthData;
-};
+export function Information() {
+  const authData = useAtomValue(authAtom);
 
-export function Information({ user }: InformationProps) {
-  const { term, teamNumber, email, name, nickname, profileImageUrl } = user;
+  if (!authData) {
+    // 에러 throw 하고 에러바운더리로 처리
+    return null;
+  }
+
+  const { term, teamNumber, email, name, nickname, profileImageUrl, course } =
+    authData;
 
   return (
-    <section className="flex flex-col gap-4 w-full">
+    <section className="flex flex-col gap-4 w-full mb-12">
       <h2 className="text-lg font-semibold">회원 정보</h2>
       <div className="flex gap-4">
         <div className="relative h-16 w-16 shrink-0">
@@ -24,7 +32,8 @@ export function Information({ user }: InformationProps) {
         <div className="flex flex-col justify-center gap-1 text-sm">
           <div className="flex items-center gap-4">
             <p className="text-base font-semibold">
-              {nickname}({name})
+              {nickname}({name})/
+              <span>{course ? COURSE[course] : '외부인'}</span>
             </p>
             <button>
               <ArrowIcon
@@ -36,10 +45,14 @@ export function Information({ user }: InformationProps) {
             </button>
           </div>
           <p className="flex flex-wrap gap-2">
-            <span className="text-dark-grey">
-              판교 {term}기, {teamNumber}팀
-            </span>
-            <span className="text-soft-grey">|</span>
+            {course && (
+              <>
+                <span className="text-dark-grey">
+                  판교 {term}기, {teamNumber}팀
+                </span>
+                <span className="text-soft-grey">|</span>
+              </>
+            )}
             <span className="text-dark-grey whitespace-pre-wrap break-all">
               {email}
             </span>

--- a/src/features/user/components/information/Information.tsx
+++ b/src/features/user/components/information/Information.tsx
@@ -1,0 +1,51 @@
+import { ArrowIcon } from '@/components/icons';
+import Image from 'next/image';
+import { MyData } from '../../schemas';
+
+type InformationProps = {
+  user: MyData;
+};
+
+export function Information({ user }: InformationProps) {
+  const { term, teamNumber, email, name, nickname, profileImageUrl } = user;
+
+  return (
+    <section className="flex flex-col gap-4 w-full">
+      <h2 className="text-lg font-semibold">회원 정보</h2>
+      <div className="flex gap-4">
+        <div className="relative h-16 w-16 shrink-0">
+          <Image
+            src={profileImageUrl}
+            alt="프로필 이미지"
+            fill
+            className="rounded-full object-cover"
+          />
+        </div>
+        <div className="flex flex-col justify-center gap-1 text-sm">
+          <div className="flex items-center gap-4">
+            <p className="text-base font-semibold">
+              {nickname}({name})
+            </p>
+            <button>
+              <ArrowIcon
+                width={20}
+                height={20}
+                fill="var(--color-dark-grey)"
+                className="rotate-90"
+              />
+            </button>
+          </div>
+          <p className="flex flex-wrap gap-2">
+            <span className="text-dark-grey">
+              판교 {term}기, {teamNumber}팀
+            </span>
+            <span className="text-soft-grey">|</span>
+            <span className="text-dark-grey whitespace-pre-wrap break-all">
+              {email}
+            </span>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/user/components/information/Information.tsx
+++ b/src/features/user/components/information/Information.tsx
@@ -1,9 +1,9 @@
 import { ArrowIcon } from '@/components/icons';
 import Image from 'next/image';
-import { MyData } from '../../schemas';
+import { AuthData } from '../../schemas';
 
 type InformationProps = {
-  user: MyData;
+  user: AuthData;
 };
 
 export function Information({ user }: InformationProps) {

--- a/src/features/user/components/information/index.ts
+++ b/src/features/user/components/information/index.ts
@@ -1,0 +1,1 @@
+export * from './Information';

--- a/src/features/user/hooks/index.ts
+++ b/src/features/user/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useAttendanceState';
 export * from './useCheckAttendance';
+export * from './useDashboard';

--- a/src/features/user/hooks/useCheckAttendance.tsx
+++ b/src/features/user/hooks/useCheckAttendance.tsx
@@ -2,7 +2,7 @@
 
 import { USER_QUERY_KEY } from '@/constants/query-key';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Attendance } from '../schemas/attendance';
+import { Attendance } from '../schemas';
 import { checkAttendance } from '../services';
 
 export function useCheckAttendance() {

--- a/src/features/user/hooks/useDashboard.tsx
+++ b/src/features/user/hooks/useDashboard.tsx
@@ -1,0 +1,11 @@
+import { USER_QUERY_KEY } from '@/constants/query-key';
+import { useQuery } from '@tanstack/react-query';
+import { getDashboard } from '../services';
+
+export function useDashboard(teamId?: number | null) {
+  return useQuery({
+    queryKey: USER_QUERY_KEY.DASHBOARD(teamId!),
+    queryFn: () => getDashboard(teamId!),
+    enabled: !!teamId,
+  });
+}

--- a/src/features/user/schemas/index.ts
+++ b/src/features/user/schemas/index.ts
@@ -1,1 +1,3 @@
+export * from './attendance';
+export * from './team';
 export * from './user';

--- a/src/features/user/schemas/team.ts
+++ b/src/features/user/schemas/team.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const teamSchema = z.object({
+  id: z.number(),
+  term: z.number(),
+  number: z.number(),
+  projectId: z.number(),
+  rank: z.number(),
+  givedPumatiCount: z.number(),
+  receivedPumatiCount: z.number(),
+  badgeImageUrl: z.string(),
+  createdAt: z.string().datetime(),
+  modifiedAt: z.string().datetime(),
+});
+
+export type Team = z.infer<typeof teamSchema>;

--- a/src/features/user/schemas/user.ts
+++ b/src/features/user/schemas/user.ts
@@ -3,17 +3,20 @@ import { z } from 'zod';
 export const myDataSchema = z.object({
   id: z.number(),
   teamId: z.number(),
+  term: z.number(),
+  teamNumber: z.number(),
   email: z.string().email(),
-  password: z.string(),
   name: z.string(),
   nickname: z.string(),
-  course: z.string(),
+  course: z.enum(['FULL_STACK', 'AI', 'CLOUD']).nullable(),
   profileImageUrl: z.string().url(),
-  role: z.enum(['USER', 'ADMIN']),
+  role: z.enum(['USER', 'ADMIN', 'TRAINEE']),
   state: z.enum(['ACTIVE', 'INACTIVE']),
   createdAt: z.string().datetime(),
   modifiedAt: z.string().datetime(),
-  social: z.boolean(),
+  isSocial: z.boolean(),
+  emailOptInAt: z.string().datetime().nullable(),
+  emailOptOutAt: z.string().datetime().nullable(),
 });
 
 export type MyData = z.infer<typeof myDataSchema>;

--- a/src/features/user/schemas/user.ts
+++ b/src/features/user/schemas/user.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
-export const myDataSchema = z.object({
+export const authDataSchema = z.object({
   id: z.number(),
-  teamId: z.number(),
-  term: z.number(),
-  teamNumber: z.number(),
+  teamId: z.number().nullable(),
+  term: z.number().nullable(),
+  teamNumber: z.number().nullable(),
   email: z.string().email(),
   name: z.string(),
   nickname: z.string(),
@@ -19,4 +19,4 @@ export const myDataSchema = z.object({
   emailOptOutAt: z.string().datetime().nullable(),
 });
 
-export type MyData = z.infer<typeof myDataSchema>;
+export type AuthData = z.infer<typeof authDataSchema>;

--- a/src/features/user/services/index.ts
+++ b/src/features/user/services/index.ts
@@ -50,3 +50,23 @@ export const getAttendanceState = async (token: string) => {
         );
   }
 };
+
+export const getDashboard = async (teamId: number) => {
+  try {
+    const response = await fetch(`${BASE_URL}/api/teams/${teamId}`);
+
+    if (!response.ok) {
+      throw new Error('Failed to get dashboard');
+    }
+
+    const data = await response.json();
+
+    return data.data;
+  } catch (error) {
+    console.error(error);
+
+    throw error instanceof Error
+      ? error
+      : new Error('An unexpected error occurred while getting dashboard');
+  }
+};

--- a/src/libs/tanstack-query/client.ts
+++ b/src/libs/tanstack-query/client.ts
@@ -10,6 +10,7 @@ function makeQueryClient() {
       queries: {
         staleTime: 60 * 1000,
         retry: false,
+        refetchOnWindowFocus: false,
       },
       dehydrate: {
         shouldDehydrateQuery: (query) =>

--- a/src/store/atoms/user.ts
+++ b/src/store/atoms/user.ts
@@ -1,4 +1,4 @@
-import { Auth } from '@/features/auth/schemas';
+import { AuthData } from '@/features/user/schemas';
 import { atom } from 'jotai';
 
-export const authAtom = atom<Auth | null>(null);
+export const authAtom = atom<AuthData | null>(null);


### PR DESCRIPTION
## ⭐Key Changes

1. 회원 정보 조회 기능을 구현했습니다. 회원 정보는 로그인 시 전역상태 `authAtom`에 저장하기 때문에 별도의 API 요청없이 구현하였습니다.
<div align="center">
<img width="440" alt="회원 정보 조회 기능" src="https://github.com/user-attachments/assets/d4d6344d-ef09-46f9-8b45-bd9e7d39a2b1" />
</div>
2. 팀 프로젝트 대시보드 조회 기능을 구현했습니다. 마이페이지 자체가 로그인 상태에만 접근할 수 있지만 혹시 유저 정보가 없는 상태를 고려하여 `useQuery`와 `enabled` 속성을 조합하여 유저 정보가 존재하는 경우에만 쿼리 요청을 하도록 구현하였습니다.
<div align="center">
<img width="416" alt="팀 프로젝트 대시보드 조회 기능" src="https://github.com/user-attachments/assets/d2135a3d-4f1e-492c-b049-952971b7c3f6" />
</div>

<br />

## 🖐️To reviewers

1. 마이페이지의 모은 뱃지 목록 조회, 구독 프로젝트 목록 조회 기능은 추후 다른 과정이 구현한 후 추가될 예정입니다.

<br />

## 📌 issue

close #104 
