### PR TITLE
AuthProvider 무한로딩 에러 해결

### DIFF
--- a/src/features/auth/components/auth-provider/AuthProvider.tsx
+++ b/src/features/auth/components/auth-provider/AuthProvider.tsx
@@ -21,19 +21,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
     isLoading: isRefreshing,
     isError: isRefreshError,
   } = useRefresh();
-  const { mutate: getAuth, isPending: isGettingAuth } = useAuth();
+  const { mutateAsync: getAuth, isPending: isGettingAuth } = useAuth();
 
   useEffect(() => {
-    if (refreshData?.accessToken) {
-      const accessToken = refreshData.accessToken;
+    const fetchAuth = async () => {
+      if (refreshData?.accessToken) {
+        const accessToken = refreshData.accessToken;
 
-      setAccessToken(accessToken);
-      getAuth(accessToken, {
-        onSuccess: () => {
-          setIsLoading(false);
-        },
-      });
-    }
+        setAccessToken(accessToken);
+        await getAuth(accessToken);
+      }
+
+      setIsLoading(false);
+    };
+
+    fetchAuth();
   }, [refreshData, getAuth, setAccessToken]);
 
   if (isRefreshError) {


### PR DESCRIPTION
## ⭐Key Changes

1. refreshToken이 존재하는 경우만 로딩 state를 false로 처리해서 비로그인 상태에서 무한로딩되는 문제가 발생했습니다. 따라서 refreshToken이 존재하는 경우 유저 정보를 조회한 뒤, 존재하지 않는 경우 바로 로딩 state를 false로 처리하게 로직을 변경했습니다.

