### PR TITLE
본인 프로젝트 품앗이 막기

### DIFF
--- a/src/features/project/components/project-detail-container/Description.tsx
+++ b/src/features/project/components/project-detail-container/Description.tsx
@@ -51,7 +51,7 @@ export function Description({
     router.push(`/projects/${id}/edit`);
   };
   const handleOpenProject = () => {
-    if (accessToken) {
+    if (accessToken && auth && auth.teamId) {
       receivePumati(
         { token: accessToken, teamId },
         {

--- a/src/features/project/components/project-detail-container/Description.tsx
+++ b/src/features/project/components/project-detail-container/Description.tsx
@@ -43,19 +43,26 @@ export function Description({
   const auth = useAtomValue(authAtom);
   const accessToken = useAtomValue(accessTokenAtom);
 
-  const { mutateAsync: givePumati } = useGivePumati();
-  const { mutateAsync: receivePumati } = useReceivePumati();
+  const { mutate: givePumati } = useGivePumati();
+  const { mutate: receivePumati } = useReceivePumati();
   const { mutate: receiveBadge } = useReceiveBadge();
 
   const handleEditButtonClick = () => {
     router.push(`/projects/${id}/edit`);
   };
-  const handleOpenProject = async () => {
-    if (auth && auth.teamId && accessToken) {
-      await givePumati({ token: accessToken, teamId: auth.teamId });
-      await receivePumati({ token: accessToken, teamId });
-      receiveBadge({ token: accessToken, teamId });
-      router.refresh();
+  const handleOpenProject = () => {
+    if (accessToken) {
+      receivePumati(
+        { token: accessToken, teamId },
+        {
+          onSuccess: () => {
+            if (!auth || !auth.teamId) return;
+
+            givePumati({ token: accessToken, teamId: auth.teamId });
+            receiveBadge({ token: accessToken, teamId });
+          },
+        },
+      );
     }
 
     window.open(deploymentUrl, '_blank', 'noopener,noreferrer');


### PR DESCRIPTION
## ⭐Key Changes

1. 본인 프로젝트에 대한 품앗이 주기/받기, 뱃지 획득 기능을 제한했습니다. 본인 프로젝트인 경우 품앗이 받기 요청에서 에러가 발생하고, 그런 경우 품앗이 주기, 뱃지 획득 요청을 하지 않습니다.
2. 외부인의 경우 유저 정보의 `teamId`를 사용해 분기처리하여 품앗이 및 뱃지 관련 API 요청을 하지 않습니다.

<br />

## 📌 Issue

close #143 