### PR TITLE
다른 팀 프로젝트 수정 페이지 접근 제한

### DIFF
--- a/src/features/project/components/edit-form/EditForm.tsx
+++ b/src/features/project/components/edit-form/EditForm.tsx
@@ -8,7 +8,7 @@ import { authAtom } from '@/store';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useEditProject } from '../../hooks';
 import {
@@ -29,6 +29,7 @@ export function EditForm({ project }: EditFormProps) {
   const {
     id,
     images,
+    teamId,
     title,
     introduction,
     deploymentUrl,
@@ -101,6 +102,13 @@ export function EditForm({ project }: EditFormProps) {
       },
     );
   };
+
+  useEffect(() => {
+    if (teamId !== auth?.teamId) {
+      alert('프로젝트 수정 권한이 없습니다.');
+      router.replace(PROJECT_PATH.DETAIL(id.toString()));
+    }
+  }, [teamId, auth, router, id]);
   return (
     <FormProvider {...methods}>
       <form


### PR DESCRIPTION
## ⭐Key Changes

1. 프로젝트 수정 페이지 접근 시 `useEffect`로 `teamId`를 확인해서 다른 팀의 프로젝트인 경우 프로젝트 상세 페이지로 리다이렉트시켰습니다.

<br />

## 📌 issue

close #146 
