### PR TITLE
품앗이 툴팁

### DIFF
--- a/src/components/icons/InfoIcon.tsx
+++ b/src/components/icons/InfoIcon.tsx
@@ -1,0 +1,33 @@
+export function InfoIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width="24px"
+      height="24px"
+      strokeWidth="1.5"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      color="#000000"
+      {...props}
+    >
+      <path
+        d="M12 11.5V16.5"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      ></path>
+      <path
+        d="M12 7.51L12.01 7.49889"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      ></path>
+      <path
+        d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      ></path>
+    </svg>
+  );
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -2,6 +2,7 @@ export * from './ArrowIcon';
 export * from './CancelIcon';
 export * from './DotMenuIcon';
 export * from './EditIcon';
+export * from './InfoIcon';
 export * from './KakaoIcon';
 export * from './LogoIcon';
 export * from './MenuIcon';

--- a/src/features/project/components/project-detail-container/Dashboard.tsx
+++ b/src/features/project/components/project-detail-container/Dashboard.tsx
@@ -1,5 +1,7 @@
+import { InfoIcon } from '@/components/icons';
 import { abbreviateCountToK } from '@/utils/count';
 import { ProjectDashboard } from '../../schemas';
+import { Tooltip } from './Tooltip';
 
 type DashboardProps = ProjectDashboard;
 
@@ -27,7 +29,18 @@ export function Dashboard({
   ];
   return (
     <section className="flex flex-col gap-3 p-4 pb-6 bg-soft-blue rounded-lg max-w-[25rem] mx-auto">
-      <h2 className="text-lg font-semibold">대시보드</h2>
+      <div className="flex justify-between items-center">
+        <h2 className="text-lg font-semibold">대시보드</h2>
+        <div className="relative group">
+          <InfoIcon
+            width={22}
+            height={22}
+            stroke="var(--color-dark-grey)"
+            className="cursor-pointer"
+          />
+          <Tooltip />
+        </div>
+      </div>
       <ul className="flex w-full bg-white rounded-lg">
         {dashboardData.map((data) => (
           <li

--- a/src/features/project/components/project-detail-container/Tooltip.tsx
+++ b/src/features/project/components/project-detail-container/Tooltip.tsx
@@ -1,0 +1,14 @@
+export function Tooltip() {
+  return (
+    <div className="absolute top-6 right-0 p-4 hidden group-hover:block text-sm bg-black/80 text-white shadow-lg rounded-lg w-xs">
+      <h3 className="font-semibold mb-2">품앗이는?</h3>
+      <p className=" mb-1">- 다른 팀의 프로젝트를 방문하는 행위예요!</p>
+      <p>- 준 품앗이 횟수에 따라 등수가 올라가요!</p>
+      <p>- 많이 방문할수록 우리 팀의 프로젝트가 상단에 노출돼요!</p>
+      <p className="text-sm mb-1">
+        - 다른 프로젝트에 <strong>품앗이</strong>를 하면, 해당 팀에 우리 팀의{' '}
+        <strong>뱃지</strong>가 전달돼요!
+      </p>
+    </div>
+  );
+}

--- a/src/features/project/components/simple-projects/SimpleProjects.tsx
+++ b/src/features/project/components/simple-projects/SimpleProjects.tsx
@@ -23,8 +23,9 @@ export function SimpleProjects({ projects }: SimpleCardListProps) {
           품앗이 상위 <span className="text-blue">TOP3</span> 프로젝트
         </h2>
         <p className="font-medium text-dark-grey mb-4">
-          지금 커뮤니티에서 <br />
-          가장 활발한 프로젝트들을 소개할게요!
+          <span className="text-blue font-semibold">품앗이</span>를 많이 할수록{' '}
+          <br />
+          우리 팀의 프로젝트가 상단에 노출돼요!
         </p>
       </div>
       <SimpleCardList projects={projects} />


### PR DESCRIPTION
## ⭐Key Changes

1. 루트페이지(`/`) 상단 품앗이 상위 프로젝트 목록 설명을 품앗이 기능을 알 수 있게 수정했습니다.
2. 프로젝트 상세 페이지 품앗이 대시보드 섹션에 툴팁 추가
<div align="center">
<img width="427" alt="품앗이 대시보드 섹션 툴팁" src="https://github.com/user-attachments/assets/9eac4018-8d9f-4d2a-b486-86ccff261ac5" />
</div>

<br />

## 📌 issue

close #154 
