### PR TITLE
API 요청 함수 커스텀(fetch)

### DIFF
--- a/src/app/(header)/projects/page.tsx
+++ b/src/app/(header)/projects/page.tsx
@@ -4,6 +4,7 @@ import {
   ProjectsFetcher,
 } from '@/features/project/components';
 import { getSnapshot } from '@/features/project/services';
+import { ApiError } from '@/utils/error';
 import { Metadata } from 'next';
 import { Suspense } from 'react';
 
@@ -12,14 +13,17 @@ export const dynamic = 'force-dynamic';
 export const metadata: Metadata = METADATA.PROJECTS;
 
 export default async function ProjectsPage() {
-  const { id } = await getSnapshot();
+  const snapshot = await getSnapshot();
 
+  if (!snapshot) {
+    throw new ApiError(404, 'Snapshot not found');
+  }
   return (
     <section className="flex justify-center">
       <div className="flex flex-col items-center gap-4 w-full max-w-[25rem]">
         <h1 className="text-xl font-semibold my-9">프로젝트 둘러보기</h1>
         <Suspense fallback={<ProjectsFallback />}>
-          <ProjectsFetcher contextId={id} />
+          <ProjectsFetcher contextId={snapshot.id} />
         </Suspense>
       </div>
     </section>

--- a/src/features/auth/hooks/useAuth.tsx
+++ b/src/features/auth/hooks/useAuth.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { AuthData } from '@/features/user/schemas';
 import { authAtom } from '@/store/atoms/user';
+import { ApiError } from '@/utils/error';
 import { useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
 import { getMe } from '../services';
@@ -9,8 +9,14 @@ import { getMe } from '../services';
 export function useAuth() {
   const setAuth = useSetAtom(authAtom);
 
-  return useMutation<AuthData, Error, string>({
-    mutationFn: getMe,
+  return useMutation({
+    mutationFn: async (token: string) => {
+      const data = await getMe(token);
+
+      if (!data) throw new ApiError(404, 'User not found');
+
+      return data;
+    },
     onSuccess: setAuth,
     onError: (error) => {
       console.error(error);

--- a/src/features/auth/hooks/useRefresh.tsx
+++ b/src/features/auth/hooks/useRefresh.tsx
@@ -1,10 +1,9 @@
 import { AUTH_QUERY_KEY } from '@/constants';
 import { useQuery } from '@tanstack/react-query';
-import { RefreshResponse } from '../schemas';
 import { refresh } from '../services';
 
 export function useRefresh() {
-  return useQuery<RefreshResponse, Error>({
+  return useQuery({
     queryKey: AUTH_QUERY_KEY.REFRESH,
     queryFn: refresh,
   });

--- a/src/features/auth/hooks/useSignup.tsx
+++ b/src/features/auth/hooks/useSignup.tsx
@@ -6,6 +6,8 @@ import { useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { signup } from '../services';
+import { NonTraineeSignupData, SignupData } from '../schemas';
+import { ApiError } from '@/utils/error';
 
 export function useSignup() {
   const router = useRouter();
@@ -13,7 +15,13 @@ export function useSignup() {
   const setAccessToken = useSetAtom(accessTokenAtom);
 
   return useMutation({
-    mutationFn: signup,
+    mutationFn: async (signupData: SignupData | NonTraineeSignupData) => {
+      const data = await signup(signupData);
+
+      if (!data) throw new ApiError(404, 'Signup failed');
+
+      return data;
+    },
     onSuccess: (data) => {
       setAccessToken(data.accessToken);
     },

--- a/src/features/auth/hooks/useTeamList.tsx
+++ b/src/features/auth/hooks/useTeamList.tsx
@@ -5,17 +5,16 @@ import { AUTH_QUERY_KEY } from '@/constants';
 import { getTeamList } from '@/features/auth/services';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { TeamList } from '../schemas/signup';
 
 export function useTeamList() {
-  const { data: teamList, error } = useSuspenseQuery<TeamList>({
+  const { data: teamList, error } = useSuspenseQuery({
     queryKey: AUTH_QUERY_KEY.TEAM_LIST,
     queryFn: getTeamList,
   });
 
   const termOptions = useMemo(
     () =>
-      teamList.map(({ term }) => ({
+      teamList!.map(({ term }) => ({
         label: `${term}기`,
         value: term,
       })),
@@ -23,7 +22,7 @@ export function useTeamList() {
   );
   const teamNumberOptions = useMemo(
     () =>
-      teamList.reduce<Record<number, DropdownOption[]>>(
+      teamList!.reduce<Record<number, DropdownOption[]>>(
         (prev, { term, teamNumbers }) => {
           prev[term] = teamNumbers.map((number) => ({
             label: `${number}팀`,

--- a/src/features/auth/schemas/signup.ts
+++ b/src/features/auth/schemas/signup.ts
@@ -72,3 +72,16 @@ export const nonTraineeSignupDataSchema = signupDataSchema.extend({
 });
 
 export type NonTraineeSignupData = z.infer<typeof nonTraineeSignupDataSchema>;
+
+export const signupResponseSchema = z.object({
+  id: z.number(),
+  teamId: z.number(),
+  email: z.string(),
+  name: z.string(),
+  nickname: z.string(),
+  role: z.enum(['TRAINEE', 'USER']),
+  state: z.enum(['ACTIVE', 'INACTIVE']),
+  accessToken: z.string(),
+});
+
+export type SignupResponse = z.infer<typeof signupResponseSchema>;

--- a/src/features/badge/components/badge-fetcher/BadgeFetcher.tsx
+++ b/src/features/badge/components/badge-fetcher/BadgeFetcher.tsx
@@ -25,7 +25,7 @@ export function BadgeFetcher() {
   return (
     <section className="flex flex-col gap-4 w-full">
       <div className="flex justify-between items-end w-full">
-        <h2 className="text-lg font-semibold">내가 모은 뱃지</h2>
+        <h2 className="text-lg font-semibold">받은 품앗이 뱃지</h2>
         {badges.length > MAX_BADGE_COUNT && (
           <button
             className="text-sm text-blue cursor-pointer hover:underline"

--- a/src/features/badge/hooks/useMyBadges.tsx
+++ b/src/features/badge/hooks/useMyBadges.tsx
@@ -13,8 +13,8 @@ export function useMyBadges(token: string | null) {
       ),
     staleTime: 1000 * 60 * 5,
     initialPageParam: {
-      nextCursorId: null,
-      nextCursorCount: null,
+      nextCursorId: null as number | null,
+      nextCursorCount: null as number | null,
     },
     getNextPageParam: (lastPage) => {
       if (!lastPage.meta.hasNext) return null;

--- a/src/features/badge/schemas/badge.ts
+++ b/src/features/badge/schemas/badge.ts
@@ -1,6 +1,12 @@
 import { BADGE_TAG_MAX_LENGTH } from '@/constants';
 import { z } from 'zod';
 
+export type PaginationMeta = {
+  nextCursorId: number | null;
+  nextCount: number | null;
+  hasNext: boolean;
+};
+
 export const badgeSchema = z.object({
   id: z.number(),
   projectId: z.number(),

--- a/src/features/chatbot/components/chatbot-panel/ChatbotPanel.tsx
+++ b/src/features/chatbot/components/chatbot-panel/ChatbotPanel.tsx
@@ -45,12 +45,12 @@ export function ChatbotPanel({
   const { mutate: sendChatbotQuestion } = useSendChatbotQuestion(
     accessToken as string,
     projectId,
-    sessionId,
+    sessionId!,
   );
   const { mutate: disconnectChatbot } = useDisconnectChatbot(
     accessToken as string,
     projectId,
-    sessionId,
+    sessionId!,
   );
 
   const handleMessage = (message: string) => {

--- a/src/features/chatbot/services/index.ts
+++ b/src/features/chatbot/services/index.ts
@@ -1,36 +1,16 @@
-const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+import { authApiClient } from '@/utils/api-client';
 
 export const createChatbotSessionId = async (
   token: string,
   projectId: string,
 ) => {
-  try {
-    const response = await fetch(
-      `${BASE_URL}/api/projects/${projectId}/chatbot/session`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      },
-    );
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data = await response.json();
-
-    return data.data;
-  } catch (error) {
-    console.error('Failed to create chatbot session id:', error);
-
-    throw error instanceof Error
-      ? error
-      : new Error(
-          'An unexpected error occurred while creating chatbot session id',
-        );
-  }
+  return authApiClient<string>(
+    `/api/projects/${projectId}/chatbot/session`,
+    token,
+    {
+      method: 'POST',
+    },
+  ).then((res) => res.data);
 };
 
 export const sendChatbotQuestion = async (
@@ -39,35 +19,14 @@ export const sendChatbotQuestion = async (
   sessionId: string,
   content: string,
 ) => {
-  try {
-    const response = await fetch(
-      `${BASE_URL}/api/projects/${projectId}/chatbot/sessions/${sessionId}/message`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ content }),
-      },
-    );
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data = await response.json();
-
-    return data;
-  } catch (error) {
-    console.error('Failed to send chatbot question:', error);
-
-    throw error instanceof Error
-      ? error
-      : new Error(
-          'An unexpected error occurred while sending chatbot question',
-        );
-  }
+  return authApiClient(
+    `/api/projects/${projectId}/chatbot/sessions/${sessionId}/message`,
+    token,
+    {
+      method: 'POST',
+      body: { content },
+    },
+  );
 };
 
 export const disconnectChatbot = async (
@@ -75,29 +34,11 @@ export const disconnectChatbot = async (
   projectId: string,
   sessionId: string,
 ) => {
-  try {
-    const response = await fetch(
-      `${BASE_URL}/api/projects/${projectId}/chatbot/sessions/${sessionId}/stream`,
-      {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      },
-    );
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data = await response.json();
-
-    return data;
-  } catch (error) {
-    console.error('Failed to disconnect chatbot:', error);
-
-    throw error instanceof Error
-      ? error
-      : new Error('An unexpected error occurred while disconnecting chatbot');
-  }
+  return authApiClient(
+    `/api/projects/${projectId}/chatbot/sessions/${sessionId}/stream`,
+    token,
+    {
+      method: 'DELETE',
+    },
+  );
 };

--- a/src/features/comment/hooks/useComments.tsx
+++ b/src/features/comment/hooks/useComments.tsx
@@ -9,7 +9,7 @@ export function useComments(projectId: number) {
       getComments(projectId, pageParam.nextCursorTime, pageParam.nextCursorId),
     initialPageParam: {
       nextCursorId: 0,
-      nextCursorTime: null,
+      nextCursorTime: null as string | null,
     },
     getNextPageParam: (lastPage) => {
       if (

--- a/src/features/comment/services/index.ts
+++ b/src/features/comment/services/index.ts
@@ -1,39 +1,15 @@
-import { CreateComment } from '../schemas';
-
-const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+import { authApiClient, infiniteApiClient } from '@/utils/api-client';
+import { CommentItem, CreateComment } from '../schemas';
 
 export const createComment = async (
   projectId: number,
   commentData: CreateComment,
   token: string,
 ) => {
-  try {
-    const response = await fetch(
-      `${BASE_URL}/api/projects/${projectId}/comments`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(commentData),
-      },
-    );
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data = await response.json();
-
-    return data.data;
-  } catch (error) {
-    console.error('Failed to create comment:', error);
-
-    throw error instanceof Error
-      ? error
-      : new Error('An unexpected error occurred while creating a comment');
-  }
+  return authApiClient(`/api/projects/${projectId}/comments`, token, {
+    method: 'POST',
+    body: commentData,
+  }).then((res) => res.data);
 };
 
 export const getComments = async (
@@ -42,25 +18,9 @@ export const getComments = async (
   cursorId: number = 0,
   pageSize: number = 10,
 ) => {
-  try {
-    const response = await fetch(
-      `${BASE_URL}/api/projects/${projectId}/comments?cursor-id=${cursorId}${cursorTime ? `&cursor-time=${cursorTime}` : ''}&page-size=${pageSize}`,
-    );
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data = await response.json();
-
-    return data;
-  } catch (error) {
-    console.error('Failed to get comments:', error);
-
-    throw error instanceof Error
-      ? error
-      : new Error('An unexpected error occurred while getting comments');
-  }
+  return infiniteApiClient<CommentItem>(
+    `/api/projects/${projectId}/comments?cursor-id=${cursorId}${cursorTime ? `&cursor-time=${cursorTime}` : ''}&page-size=${pageSize}`,
+  );
 };
 
 export const editComment = async (
@@ -68,53 +28,14 @@ export const editComment = async (
   content: CreateComment,
   token: string,
 ) => {
-  try {
-    const response = await fetch(`${BASE_URL}/api/comments/${commentId}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(content),
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data = await response.json();
-
-    return data;
-  } catch (error) {
-    console.error('Failed to edit comment:', error);
-
-    throw error instanceof Error
-      ? error
-      : new Error('An unexpected error occurred while editing a comment');
-  }
+  return authApiClient(`/api/comments/${commentId}`, token, {
+    method: 'PUT',
+    body: content,
+  });
 };
 
 export const deleteComment = async (commentId: number, token: string) => {
-  try {
-    const response = await fetch(`${BASE_URL}/api/comments/${commentId}`, {
-      method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data = await response.json();
-
-    return data.data;
-  } catch (error) {
-    console.error('Failed to delete comment:', error);
-
-    throw error instanceof Error
-      ? error
-      : new Error('An unexpected error occurred while deleting a comment');
-  }
+  return authApiClient(`/api/comments/${commentId}`, token, {
+    method: 'DELETE',
+  }).then((res) => res.data);
 };

--- a/src/features/project/components/project-detail-container/MemberList.tsx
+++ b/src/features/project/components/project-detail-container/MemberList.tsx
@@ -1,4 +1,3 @@
-import { TeamMember } from '../../schemas';
 import { getTeamMembers } from '../../services';
 import { MemberItem } from './MemberItem';
 
@@ -7,18 +6,24 @@ type MemberListProps = {
 };
 
 export async function MemberList({ teamId }: MemberListProps) {
-  const teamMembers: TeamMember[] = await getTeamMembers(teamId);
+  const teamMembers = await getTeamMembers(teamId);
 
   return (
     <section>
       <h2 className="text-lg font-semibold mt-16 mb-4">
         이 프로젝트를 만든 팀이에요
       </h2>
-      <ul className="flex flex-col">
-        {teamMembers.map((member) => (
-          <MemberItem key={member.id} member={member} />
-        ))}
-      </ul>
+      {teamMembers && teamMembers.length > 0 ? (
+        <ul className="flex flex-col">
+          {teamMembers.map((member) => (
+            <MemberItem key={member.id} member={member} />
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-center text-gray-500">
+          아직 팀원이 없습니다.
+        </p>
+      )}
     </section>
   );
 }

--- a/src/features/project/components/ranked-projects/RankedProjects.tsx
+++ b/src/features/project/components/ranked-projects/RankedProjects.tsx
@@ -1,10 +1,15 @@
+import { ApiError } from '@/utils/error';
 import { getRankedProjects, getSnapshot } from '../../services';
 import { SimpleProjects } from '../simple-projects';
 
 export async function RankedProjects() {
-  const { id } = await getSnapshot();
+  const snapshot = await getSnapshot();
 
-  const { data: projects } = await getRankedProjects(id, 0, 3);
+  if (!snapshot) {
+    throw new ApiError(404, 'Snapshot not found');
+  }
+
+  const { data: projects } = await getRankedProjects(snapshot.id, 0, 3);
 
   return <SimpleProjects projects={projects} />;
 }

--- a/src/features/project/hooks/useCreateProject.tsx
+++ b/src/features/project/hooks/useCreateProject.tsx
@@ -11,8 +11,9 @@ export function useCreateProject() {
 
   const queryClient = getQueryClient();
 
-  return useMutation<{ id: number }, Error, NewProject>({
-    mutationFn: (data) => createProject(data, accessToken as string),
+  return useMutation({
+    mutationFn: (data: NewProject) =>
+      createProject(data, accessToken as string),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: PROJECT_QUERY_KEY.RANKED_PROJECTS,

--- a/src/features/project/hooks/useProjects.tsx
+++ b/src/features/project/hooks/useProjects.tsx
@@ -1,6 +1,5 @@
 import { PROJECT_QUERY_KEY } from '@/constants';
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
-import { ProjectInfiniteScrollResponse } from '../schemas';
 import { getRankedProjects } from '../services';
 
 export function useProjects(contextId: number) {

--- a/src/features/project/hooks/useProjects.tsx
+++ b/src/features/project/hooks/useProjects.tsx
@@ -4,7 +4,7 @@ import { ProjectInfiniteScrollResponse } from '../schemas';
 import { getRankedProjects } from '../services';
 
 export function useProjects(contextId: number) {
-  return useSuspenseInfiniteQuery<ProjectInfiniteScrollResponse>({
+  return useSuspenseInfiniteQuery({
     queryKey: PROJECT_QUERY_KEY.RANKED_PROJECTS,
     queryFn: ({ pageParam }) =>
       getRankedProjects(contextId, pageParam as number),

--- a/src/features/project/schemas/new-project.ts
+++ b/src/features/project/schemas/new-project.ts
@@ -71,6 +71,10 @@ export const newProjectFormSchema = z.object({
 
 export type NewProjectForm = z.infer<typeof newProjectFormSchema>;
 
+export const newProjectResponseSchema = z.object({ id: z.number() });
+
+export type NewProjectResponse = z.infer<typeof newProjectResponseSchema>;
+
 export const editProjectFormSchema = newProjectFormSchema.extend({
   images: z
     .array(editImageFormSchema)

--- a/src/features/project/schemas/project.ts
+++ b/src/features/project/schemas/project.ts
@@ -12,6 +12,14 @@ export type InfiniteScrollResponse<T> = {
   meta: PaginationMeta;
 };
 
+const projectExistenceResponseSchema = z.object({
+  exists: z.boolean(),
+});
+
+export type ProjectExistenceResponse = z.infer<
+  typeof projectExistenceResponseSchema
+>;
+
 const projectImageSchema = z.object({
   id: z.number(),
   projectId: z.number(),

--- a/src/features/project/schemas/project.ts
+++ b/src/features/project/schemas/project.ts
@@ -1,16 +1,5 @@
+import { InfiniteScrollResponse } from '@/schemas';
 import { z } from 'zod';
-
-export type PaginationMeta = {
-  nextCursorId: number;
-  nextCursorTime: string;
-  hasNext: boolean;
-};
-
-export type InfiniteScrollResponse<T> = {
-  message: string;
-  data: T[];
-  meta: PaginationMeta;
-};
 
 const projectExistenceResponseSchema = z.object({
   exists: z.boolean(),

--- a/src/features/project/schemas/project.ts
+++ b/src/features/project/schemas/project.ts
@@ -1,6 +1,7 @@
 import { InfiniteScrollResponse } from '@/schemas';
 import { z } from 'zod';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const projectExistenceResponseSchema = z.object({
   exists: z.boolean(),
 });

--- a/src/features/user/components/attendance/Attendance.tsx
+++ b/src/features/user/components/attendance/Attendance.tsx
@@ -30,8 +30,8 @@ export function Attendance() {
     }
 
     setIsAttendanceModalOpen(true);
-    const { devLuck } = await checkAttendance(accessToken);
-    setLuckMessage(devLuck.overall);
+    const attendanceData = await checkAttendance(accessToken);
+    setLuckMessage(attendanceData!.devLuck.overall);
   };
   return (
     <article className="flex flex-col items-center justify-center gap-4 p-8 my-10 bg-blue-white">

--- a/src/features/user/components/dashboard/DashboardFetcher.tsx
+++ b/src/features/user/components/dashboard/DashboardFetcher.tsx
@@ -20,7 +20,7 @@ export function DashboardFetcher() {
   }
 
   const handleBrowseProjectsClick = () => {
-    router.push(PROJECT_PATH.DETAIL(dashboard?.projectId));
+    router.push(PROJECT_PATH.DETAIL(dashboard!.projectId.toString()));
   };
   return (
     <section className="flex flex-col items-center gap-4 w-full">
@@ -38,7 +38,7 @@ export function DashboardFetcher() {
           {isLoading ? (
             <DashboardFallback />
           ) : (
-            <Dashboard dashboard={dashboard} />
+            <Dashboard dashboard={dashboard!} />
           )}
         </>
       ) : (

--- a/src/features/user/hooks/useCheckAttendance.tsx
+++ b/src/features/user/hooks/useCheckAttendance.tsx
@@ -2,13 +2,12 @@
 
 import { USER_QUERY_KEY } from '@/constants';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Attendance } from '../schemas';
 import { checkAttendance } from '../services';
 
 export function useCheckAttendance() {
   const queryClient = useQueryClient();
 
-  return useMutation<Attendance, Error, string>({
+  return useMutation({
     mutationFn: checkAttendance,
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/src/features/user/schemas/attendance.ts
+++ b/src/features/user/schemas/attendance.ts
@@ -9,3 +9,20 @@ export const attendanceSchema = z.object({
 });
 
 export type Attendance = z.infer<typeof attendanceSchema>;
+
+export const attendanceStateSchema = z.object({
+  today: z.boolean(),
+  weekly: z.object({
+    monday: z.boolean(),
+    tuesday: z.boolean(),
+    wednesday: z.boolean(),
+    thursday: z.boolean(),
+    friday: z.boolean(),
+    saturday: z.boolean(),
+    sunday: z.boolean(),
+  }),
+  streak: z.number(),
+  lastCheckedDate: z.string().datetime(),
+});
+
+export type AttendanceState = z.infer<typeof attendanceStateSchema>;

--- a/src/features/user/services/index.ts
+++ b/src/features/user/services/index.ts
@@ -1,130 +1,40 @@
-import { UserProfileEditData } from '../schemas';
-
-const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+import { apiClient, authApiClient } from '@/utils/api-client';
+import {
+  Attendance,
+  AttendanceState,
+  Team,
+  UserProfileEditData,
+} from '../schemas';
 
 export const checkAttendance = async (token: string) => {
-  try {
-    const response = await fetch(`${BASE_URL}/api/attendances`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error('Failed to check attendance');
-    }
-
-    const data = await response.json();
-
-    return data.data;
-  } catch (error) {
-    console.error(error);
-
-    throw error instanceof Error
-      ? error
-      : new Error('An unexpected error occurred while checking attendance');
-  }
+  return authApiClient<Attendance>('/api/attendances', token, {
+    method: 'POST',
+  }).then((res) => res.data);
 };
 
 export const getAttendanceState = async (token: string) => {
-  try {
-    const response = await fetch(`${BASE_URL}/api/attendances`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error('Failed to get attendance state');
-    }
-
-    const data = await response.json();
-
-    return data.data;
-  } catch (error) {
-    console.error(error);
-
-    throw error instanceof Error
-      ? error
-      : new Error(
-          'An unexpected error occurred while getting attendance state',
-        );
-  }
+  return authApiClient<AttendanceState>('/api/attendances', token).then(
+    (res) => res.data,
+  );
 };
 
 export const getDashboard = async (teamId: number) => {
-  try {
-    const response = await fetch(`${BASE_URL}/api/teams/${teamId}`);
-
-    if (!response.ok) {
-      throw new Error('Failed to get dashboard');
-    }
-
-    const data = await response.json();
-
-    return data.data;
-  } catch (error) {
-    console.error(error);
-
-    throw error instanceof Error
-      ? error
-      : new Error('An unexpected error occurred while getting dashboard');
-  }
+  return apiClient<Team>(`/api/teams/${teamId}`).then((res) => res.data);
 };
 
 export const editUserProfile = async (
   token: string,
   userData: UserProfileEditData,
 ) => {
-  try {
-    const response = await fetch(`${BASE_URL}/api/members/me`, {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(userData),
-    });
-
-    if (!response.ok) {
-      throw new Error('Failed to edit user profile');
-    }
-
-    const data = await response.json();
-
-    return data;
-  } catch (error) {
-    console.error(error);
-
-    throw error instanceof Error
-      ? error
-      : new Error('An unexpected error occurred while editing user profile');
-  }
+  return authApiClient('/api/members/me', token, {
+    method: 'PUT',
+    body: userData,
+  });
 };
 
 export const withdraw = async (token: string) => {
-  try {
-    const response = await fetch(`${BASE_URL}/api/members/me`, {
-      method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      credentials: 'include',
-    });
-
-    if (!response.ok) {
-      throw new Error('Failed to withdraw');
-    }
-
-    const data = await response.json();
-
-    return data;
-  } catch (error) {
-    console.error(error);
-
-    throw error instanceof Error
-      ? error
-      : new Error('An unexpected error occurred while withdrawing');
-  }
+  return authApiClient('/api/members/me', token, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
 };

--- a/src/schemas/api-client.ts
+++ b/src/schemas/api-client.ts
@@ -1,0 +1,11 @@
+export type PaginationMeta = {
+  nextCursorId: number;
+  nextCursorTime: string;
+  hasNext: boolean;
+};
+
+export type InfiniteScrollResponse<T, M = PaginationMeta> = {
+  message: string;
+  data: T[];
+  meta: M;
+};

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,1 +1,2 @@
+export * from './api-client';
 export * from './image';

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -1,4 +1,4 @@
-import { InfiniteScrollResponse } from '@/features/project/schemas';
+import { InfiniteScrollResponse, PaginationMeta } from '@/schemas';
 import { ApiError } from './error';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -17,10 +17,10 @@ interface ApiResponse<T> {
   message: string;
 }
 
-async function fetchWithConfig<T>(
+export const fetchWithConfig = async <T>(
   endpoint: string,
   config: RequestConfig = {},
-): Promise<T> {
+): Promise<T> => {
   const { method = 'GET', headers = {}, body, credentials } = config;
 
   try {
@@ -48,27 +48,27 @@ async function fetchWithConfig<T>(
 
     throw new ApiError(500, 'An unexpected error occurred');
   }
-}
+};
 
-export async function apiClient<T>(
+export const apiClient = async <T>(
   endpoint: string,
   config: RequestConfig = {},
-): Promise<ApiResponse<T>> {
+): Promise<ApiResponse<T>> => {
   return fetchWithConfig<ApiResponse<T>>(endpoint, config);
-}
+};
 
-export async function infiniteApiClient<T>(
+export const infiniteApiClient = async <T, M = PaginationMeta>(
   endpoint: string,
   config: RequestConfig = {},
-): Promise<InfiniteScrollResponse<T>> {
-  return fetchWithConfig<InfiniteScrollResponse<T>>(endpoint, config);
-}
+): Promise<InfiniteScrollResponse<T, M>> => {
+  return fetchWithConfig<InfiniteScrollResponse<T, M>>(endpoint, config);
+};
 
-export function authApiClient<T>(
+export const authApiClient = async <T>(
   endpoint: string,
   token: string,
   config: RequestConfig = {},
-) {
+) => {
   return apiClient<T>(endpoint, {
     ...config,
     headers: {
@@ -76,4 +76,18 @@ export function authApiClient<T>(
       ...config.headers,
     },
   });
-}
+};
+
+export const authInfiniteApiClient = <T, M = PaginationMeta>(
+  endpoint: string,
+  token: string,
+  config: RequestConfig = {},
+) => {
+  return infiniteApiClient<T, M>(endpoint, {
+    ...config,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...config.headers,
+    },
+  });
+};

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -1,0 +1,79 @@
+import { InfiniteScrollResponse } from '@/features/project/schemas';
+import { ApiError } from './error';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+type RequestMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+interface RequestConfig {
+  method?: RequestMethod;
+  headers?: Record<string, string>;
+  body?: any;
+  credentials?: RequestCredentials;
+}
+
+interface ApiResponse<T> {
+  data?: T;
+  message: string;
+}
+
+async function fetchWithConfig<T>(
+  endpoint: string,
+  config: RequestConfig = {},
+): Promise<T> {
+  const { method = 'GET', headers = {}, body, credentials } = config;
+
+  try {
+    const response = await fetch(`${BASE_URL}${endpoint}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      credentials,
+    });
+
+    if (!response.ok) {
+      throw new ApiError(response.status, response.statusText);
+    }
+
+    const data = await response.json();
+
+    return data;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+
+    throw new ApiError(500, 'An unexpected error occurred');
+  }
+}
+
+export async function apiClient<T>(
+  endpoint: string,
+  config: RequestConfig = {},
+): Promise<ApiResponse<T>> {
+  return fetchWithConfig<ApiResponse<T>>(endpoint, config);
+}
+
+export async function infiniteApiClient<T>(
+  endpoint: string,
+  config: RequestConfig = {},
+): Promise<InfiniteScrollResponse<T>> {
+  return fetchWithConfig<InfiniteScrollResponse<T>>(endpoint, config);
+}
+
+export function authApiClient<T>(
+  endpoint: string,
+  token: string,
+  config: RequestConfig = {},
+) {
+  return apiClient<T>(endpoint, {
+    ...config,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...config.headers,
+    },
+  });
+}

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -8,6 +8,7 @@ type RequestMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 interface RequestConfig {
   method?: RequestMethod;
   headers?: Record<string, string>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   body?: any;
   credentials?: RequestCredentials;
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,10 +1,10 @@
-import { addHours, formatDate, formatDistanceToNow } from 'date-fns';
+import { formatDate, formatDistanceToNow } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
 export const dateYYYYMMDD = (date: string) => formatDate(date, 'yyyy.MM.dd');
 
 export const dateDistance = (date: string) => {
-  const distance = formatDistanceToNow(addHours(new Date(date), 9), {
+  const distance = formatDistanceToNow(date, {
     locale: ko,
     addSuffix: true,
   });

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,11 @@
+export class ApiError extends Error {
+  public readonly statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+
+    this.statusCode = statusCode;
+
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+}


### PR DESCRIPTION
## ⭐Key Changes

1. 각 API 요청에 대한 함수에서 `fetch`를 사용하여 에러처리, json 파싱, 500대 에러가 아닌 응답에 대한 처리 등의 코드 반복을 줄이기 위해 API 요청 함수를 구현했습니다.
2. 기본적인 로직을 구현한 `fetchWithConfig`와 이 함수를 사용해 API 요청을 보내는 각 함수를 구현했습니다.(권한의 유무, 무한스크롤로 구분)
3. 커스텀 함수 구현 후 모든 API 요청 함수에 적용하였습니다.

<br />

## 🖐️To reviewers

1. 무한 스크롤 API의 경우 응답의 `meta` 데이터 타입이 다를 수 있어 제네릭으로 입력받을 수 있게 구현하였습니다.

<br />

## 📌 issue

- close #102 
