### PR TITLE
build 에러 해결

### DIFF
--- a/src/features/project/components/create-form/CreateForm.tsx
+++ b/src/features/project/components/create-form/CreateForm.tsx
@@ -60,8 +60,8 @@ export function CreateForm() {
         teamId: auth.teamId,
       },
       {
-        onSuccess: ({ id }) => {
-          router.replace(PROJECT_PATH.DETAIL(id.toString()));
+        onSuccess: (data) => {
+          router.replace(PROJECT_PATH.DETAIL(data!.id.toString()));
         },
         onSettled: () => {
           setIsSubmitting(false);


### PR DESCRIPTION
## ⭐Key Changes

1. 커스텀 fetch 적용하면서 응답이 undefined 일 수 있는데, 처리를 하지않아 발생하는 빌드에러 해결

