### PR TITLE
토큰 재발급 기능 구현

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { navbarAtom } from '@/store';
+import { navbarAtom } from '@/store/atoms';
 import { cn } from '@/utils/style';
 import { useAtom } from 'jotai';
 import Link from 'next/link';

--- a/src/components/header/NavBar.tsx
+++ b/src/components/header/NavBar.tsx
@@ -1,7 +1,7 @@
 import { AUTH_PATH, PROJECT_PATH, ROOT_PATH, USER_PATH } from '@/constants';
 import { useLogout } from '@/features/auth/hooks';
 import { useOutsideClick } from '@/hooks';
-import { isLoggedInAtom, navbarAtom } from '@/store';
+import { isLoggedInAtom, navbarAtom } from '@/store/atoms';
 import { cn } from '@/utils/style';
 import { useAtom, useAtomValue } from 'jotai';
 import Link from 'next/link';

--- a/src/components/header/NavMenuItem.tsx
+++ b/src/components/header/NavMenuItem.tsx
@@ -1,4 +1,4 @@
-import { navbarAtom } from '@/store';
+import { navbarAtom } from '@/store/atoms';
 import { useSetAtom } from 'jotai';
 import Link from 'next/link';
 

--- a/src/features/auth/components/auth-provider/AuthProvider.tsx
+++ b/src/features/auth/components/auth-provider/AuthProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { SpinnerIcon } from '@/components/icons';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useSetAtom } from 'jotai';
 import { ReactNode, useEffect, useState } from 'react';
 import { useAuth } from '../../hooks';

--- a/src/features/auth/components/login-callback-content/LoginCallbackContent.tsx
+++ b/src/features/auth/components/login-callback-content/LoginCallbackContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AUTH_PATH, ROOT_PATH } from '@/constants';
-import { accessTokenAtom, signupTokenAtom } from '@/store';
+import { accessTokenAtom, signupTokenAtom } from '@/store/atoms';
 import { useSetAtom } from 'jotai';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';

--- a/src/features/auth/components/signup/container/SignupContainer.tsx
+++ b/src/features/auth/components/signup/container/SignupContainer.tsx
@@ -7,7 +7,7 @@ import {
   SignupForm as SignupFormData,
 } from '@/features/auth/schemas';
 import { useUploadFileToS3 } from '@/hooks';
-import { isCodeVerifiedAtom, signupTokenAtom } from '@/store';
+import { isCodeVerifiedAtom, signupTokenAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';

--- a/src/features/auth/components/signup/form/SecondStep.tsx
+++ b/src/features/auth/components/signup/form/SecondStep.tsx
@@ -5,7 +5,7 @@ import { ROOT_PATH } from '@/constants';
 import { useAuth, useSignup, useTeamList } from '@/features/auth/hooks';
 import { NonTraineeSignupData } from '@/features/auth/schemas';
 import { useUploadFileToS3 } from '@/hooks';
-import { isCodeVerifiedAtom, signupTokenAtom } from '@/store';
+import { isCodeVerifiedAtom, signupTokenAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { useFormContext, useWatch } from 'react-hook-form';

--- a/src/features/auth/hooks/useAuth.tsx
+++ b/src/features/auth/hooks/useAuth.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { authAtom } from '@/store/atoms/user';
+import { authAtom } from '@/store/atoms';
 import { ApiError } from '@/utils/error';
 import { useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';

--- a/src/features/auth/hooks/useCodeVerification.tsx
+++ b/src/features/auth/hooks/useCodeVerification.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { isCodeVerifiedAtom } from '@/store';
+import { isCodeVerifiedAtom } from '@/store/atoms';
 import { useSetAtom } from 'jotai';
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';

--- a/src/features/auth/hooks/useLogout.tsx
+++ b/src/features/auth/hooks/useLogout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ROOT_PATH } from '@/constants';
-import { accessTokenAtom, authAtom } from '@/store';
+import { accessTokenAtom, authAtom } from '@/store/atoms';
 import { useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';

--- a/src/features/auth/hooks/useSignup.tsx
+++ b/src/features/auth/hooks/useSignup.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AUTH_PATH } from '@/constants';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';

--- a/src/features/badge/components/badges-container/BadgesContainer.tsx
+++ b/src/features/badge/components/badges-container/BadgesContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AlertModal, ModalPortal } from '@/components';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { useState } from 'react';
 import { useMyBadges } from '../../hooks';

--- a/src/features/badge/components/badges-container/BadgesContainer.tsx
+++ b/src/features/badge/components/badges-container/BadgesContainer.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { AlertModal, ModalPortal } from '@/components';
-import { accessTokenAtom } from '@/store/atoms';
-import { useAtomValue } from 'jotai';
 import { useState } from 'react';
 import { useMyBadges } from '../../hooks';
 import { BadgeList } from '../badge-list';
@@ -13,10 +11,8 @@ const MAX_BADGE_COUNT = 12;
 export function BadgesContainer() {
   const [isBadgeListModalOpen, setIsBadgeListModalOpen] = useState(false);
 
-  const accessToken = useAtomValue(accessTokenAtom);
-
   const { data, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } =
-    useMyBadges(accessToken);
+    useMyBadges();
   const badges = data?.pages.flatMap((page) => page.data) ?? [];
 
   const handleBadgeListModalToggle = () => {

--- a/src/features/badge/components/edit-badge-modal-content/EditBadgeModalContent.tsx
+++ b/src/features/badge/components/edit-badge-modal-content/EditBadgeModalContent.tsx
@@ -3,7 +3,7 @@
 import { ConfirmModal, ModalPortal } from '@/components';
 import { SpinnerIcon } from '@/components/icons';
 import { AUTH_PATH, BADGE_TAG_MAX_LENGTH } from '@/constants';
-import { accessTokenAtom, authAtom } from '@/store';
+import { accessTokenAtom, authAtom } from '@/store/atoms';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';

--- a/src/features/badge/hooks/useMyBadges.tsx
+++ b/src/features/badge/hooks/useMyBadges.tsx
@@ -1,17 +1,20 @@
 import { USER_QUERY_KEY } from '@/constants';
+import { accessTokenAtom } from '@/store/atoms';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
 import { getMyBadges } from '../services';
 
-export function useMyBadges(token: string | null) {
+export function useMyBadges() {
+  const accessToken = useAtomValue(accessTokenAtom);
+
   return useInfiniteQuery({
     queryKey: USER_QUERY_KEY.BADGES,
     queryFn: ({ pageParam }) =>
       getMyBadges(
-        token as string,
+        accessToken as string,
         pageParam.nextCursorId,
         pageParam.nextCursorCount,
       ),
-    staleTime: 1000 * 60 * 5,
     initialPageParam: {
       nextCursorId: null as number | null,
       nextCursorCount: null as number | null,
@@ -24,6 +27,6 @@ export function useMyBadges(token: string | null) {
         nextCursorCount: lastPage.meta.nextCount,
       };
     },
-    enabled: !!token,
+    enabled: !!accessToken,
   });
 }

--- a/src/features/chatbot/components/chatbot-panel/ChatbotPanel.tsx
+++ b/src/features/chatbot/components/chatbot-panel/ChatbotPanel.tsx
@@ -1,6 +1,6 @@
 import { CancelIcon } from '@/components/icons';
 import { useLockOutsideScroll } from '@/hooks';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { Dispatch, RefObject, useEffect } from 'react';
 import {

--- a/src/features/chatbot/hooks/useSSE.tsx
+++ b/src/features/chatbot/hooks/useSSE.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { EventSourcePolyfill } from 'event-source-polyfill';
 import { useAtomValue } from 'jotai';
 import { useRef, useState } from 'react';

--- a/src/features/comment/components/comment-item/CommentItem.tsx
+++ b/src/features/comment/components/comment-item/CommentItem.tsx
@@ -1,6 +1,6 @@
 import { COURSE } from '@/constants';
 import { useOutsideClick } from '@/hooks';
-import { authAtom } from '@/store';
+import { authAtom } from '@/store/atoms';
 import { dateDistance } from '@/utils/date';
 import { useAtomValue } from 'jotai';
 import Image from 'next/image';

--- a/src/features/comment/components/comment-item/CommentMenu.tsx
+++ b/src/features/comment/components/comment-item/CommentMenu.tsx
@@ -1,7 +1,7 @@
 import { ConfirmModal, ModalPortal } from '@/components';
 import { DotMenuIcon, WarningIcon } from '@/components/icons';
 import { AUTH_PATH } from '@/constants';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { useParams, useRouter } from 'next/navigation';
 import { RefObject, useState } from 'react';

--- a/src/features/comment/components/create-comment-modal-wrapper/CreateCommentModalWrapper.tsx
+++ b/src/features/comment/components/create-comment-modal-wrapper/CreateCommentModalWrapper.tsx
@@ -2,7 +2,7 @@
 
 import { ModalPortal } from '@/components';
 import { AUTH_PATH } from '@/constants';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';

--- a/src/features/comment/components/edit-comment-modal-wrapper/EditCommentModalWrapper.tsx
+++ b/src/features/comment/components/edit-comment-modal-wrapper/EditCommentModalWrapper.tsx
@@ -2,7 +2,7 @@
 
 import { ModalPortal } from '@/components';
 import { AUTH_PATH } from '@/constants';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';

--- a/src/features/project/components/create-form/CreateForm.tsx
+++ b/src/features/project/components/create-form/CreateForm.tsx
@@ -3,7 +3,7 @@
 import { Button, Textarea, TextInput } from '@/components';
 import { PROJECT_PATH, STORAGE_KEY } from '@/constants';
 import { useMultiFilesToS3 } from '@/hooks';
-import { authAtom } from '@/store';
+import { authAtom } from '@/store/atoms';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';

--- a/src/features/project/components/edit-form/EditForm.tsx
+++ b/src/features/project/components/edit-form/EditForm.tsx
@@ -4,7 +4,7 @@ import { Button, Textarea, TextInput } from '@/components';
 import { PROJECT_PATH } from '@/constants';
 import { EditBadge } from '@/features/badge/components';
 import { useMultiFilesToS3 } from '@/hooks';
-import { authAtom } from '@/store';
+import { authAtom } from '@/store/atoms';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';

--- a/src/features/project/components/project-detail-container/Description.tsx
+++ b/src/features/project/components/project-detail-container/Description.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components';
 import { EditIcon } from '@/components/icons';
 import { Badge } from '@/features/badge/components';
 import { useSendTeamBadge } from '@/features/badge/hooks';
-import { accessTokenAtom, authAtom } from '@/store';
+import { accessTokenAtom, authAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { useGivePumati, useReceivePumati } from '../../hooks';

--- a/src/features/project/hooks/useCheckProjectExists.tsx
+++ b/src/features/project/hooks/useCheckProjectExists.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PROJECT_QUERY_KEY } from '@/constants';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useQuery } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 import { checkProjectExists } from '../services';

--- a/src/features/project/hooks/useCreateProject.tsx
+++ b/src/features/project/hooks/useCreateProject.tsx
@@ -1,6 +1,6 @@
 import { PROJECT_QUERY_KEY, STORAGE_KEY } from '@/constants';
 import { getQueryClient } from '@/libs/tanstack-query';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useMutation } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 import { NewProject } from '../schemas';

--- a/src/features/project/hooks/useDeleteProject.tsx
+++ b/src/features/project/hooks/useDeleteProject.tsx
@@ -1,5 +1,5 @@
 import { PROJECT_PATH } from '@/constants';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useMutation } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';

--- a/src/features/project/hooks/useEditProject.tsx
+++ b/src/features/project/hooks/useEditProject.tsx
@@ -1,4 +1,4 @@
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useMutation } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 import { NewProject } from '../schemas';

--- a/src/features/user/components/attendance/Attendance.tsx
+++ b/src/features/user/components/attendance/Attendance.tsx
@@ -3,7 +3,7 @@
 import { AlertModal, Button, ModalPortal } from '@/components';
 import { SmallIcon } from '@/components/icons/SmallIcon';
 import { AUTH_PATH } from '@/constants';
-import { accessTokenAtom, isLoggedInAtom } from '@/store';
+import { accessTokenAtom, isLoggedInAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';

--- a/src/features/user/components/dashboard/DashboardFetcher.tsx
+++ b/src/features/user/components/dashboard/DashboardFetcher.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PROJECT_PATH } from '@/constants';
-import { authAtom } from '@/store';
+import { authAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { useDashboard } from '../../hooks';

--- a/src/features/user/components/information/Information.tsx
+++ b/src/features/user/components/information/Information.tsx
@@ -2,7 +2,7 @@
 
 import { NavArrowIcon } from '@/components/icons';
 import { COURSE, USER_PATH } from '@/constants';
-import { authAtom } from '@/store';
+import { authAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';

--- a/src/features/user/components/user-profile-edit-form/UserProfileEditForm.tsx
+++ b/src/features/user/components/user-profile-edit-form/UserProfileEditForm.tsx
@@ -3,7 +3,7 @@
 import { Button, Dropdown, TextInput } from '@/components';
 import { useTeamList } from '@/features/auth/hooks';
 import { useUploadFileToS3 } from '@/hooks';
-import { accessTokenAtom, authAtom } from '@/store';
+import { accessTokenAtom, authAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';

--- a/src/features/user/components/user-profile-edit-form/UserProfileEditForm.tsx
+++ b/src/features/user/components/user-profile-edit-form/UserProfileEditForm.tsx
@@ -3,7 +3,7 @@
 import { Button, Dropdown, TextInput } from '@/components';
 import { useTeamList } from '@/features/auth/hooks';
 import { useUploadFileToS3 } from '@/hooks';
-import { accessTokenAtom, authAtom } from '@/store/atoms';
+import { authAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -23,14 +23,13 @@ export function UserProfileEditForm() {
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
 
   const authData = useAtomValue(authAtom);
-  const accessToken = useAtomValue(accessTokenAtom);
   const { termOptions, teamNumberOptions } = useTeamList();
 
   const methods = useUserProfileEditForm(authData);
   const { handleSubmit, control, trigger, getValues } = methods;
   const { term } = useWatch({ control });
 
-  const { mutateAsync: editUserProfile } = useEditUserProfile(accessToken!);
+  const { mutate: editUserProfile } = useEditUserProfile();
   const { mutateAsync: getPresignedUrl } = useUploadFileToS3();
 
   const getEditData = async (data: UserProfileEditFormType) => {
@@ -54,7 +53,7 @@ export function UserProfileEditForm() {
   const handleTraineeEditProfile = async (data: UserProfileEditFormType) => {
     const editData = await getEditData(data);
 
-    await editUserProfile(editData);
+    editUserProfile(editData);
   };
   const handleNonTraineeEditProfile = async () => {
     const valid = await trigger(['profileImageUrl', 'name', 'nickname']);
@@ -62,7 +61,7 @@ export function UserProfileEditForm() {
       const values = getValues();
       const editData = await getEditData(values);
 
-      await editUserProfile(editData);
+      editUserProfile(editData);
     }
   };
   const handleEditClick = async () => {

--- a/src/features/user/components/withdraw-modal-content/WithdrawModalContent.tsx
+++ b/src/features/user/components/withdraw-modal-content/WithdrawModalContent.tsx
@@ -3,7 +3,7 @@
 import { ConfirmModal, ModalPortal } from '@/components';
 import { WarningIcon } from '@/components/icons';
 import { AUTH_PATH } from '@/constants';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { useWithdraw } from '../../hooks';

--- a/src/features/user/hooks/useAttendanceState.tsx
+++ b/src/features/user/hooks/useAttendanceState.tsx
@@ -1,5 +1,5 @@
 import { USER_QUERY_KEY } from '@/constants';
-import { accessTokenAtom } from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { useQuery } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 import { getAttendanceState } from '../services';

--- a/src/features/user/hooks/useEditUserProfile.tsx
+++ b/src/features/user/hooks/useEditUserProfile.tsx
@@ -3,7 +3,7 @@
 import { USER_PATH, USER_QUERY_KEY } from '@/constants';
 import { useAuth } from '@/features/auth/hooks';
 import { getQueryClient } from '@/libs/tanstack-query';
-import { authAtom } from '@/store';
+import { authAtom } from '@/store/atoms';
 import { useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';

--- a/src/features/user/hooks/useEditUserProfile.tsx
+++ b/src/features/user/hooks/useEditUserProfile.tsx
@@ -3,26 +3,30 @@
 import { USER_PATH, USER_QUERY_KEY } from '@/constants';
 import { useAuth } from '@/features/auth/hooks';
 import { getQueryClient } from '@/libs/tanstack-query';
-import { authAtom } from '@/store/atoms';
+import atomStore from '@/store';
+import { accessTokenAtom, authAtom } from '@/store/atoms';
 import { useMutation } from '@tanstack/react-query';
-import { useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { UserProfileEditData } from '../schemas';
 import { editUserProfile } from '../services';
 
-export function useEditUserProfile(token: string) {
+export function useEditUserProfile() {
   const router = useRouter();
 
   const queryClient = getQueryClient();
 
+  const accessToken = useAtomValue(accessTokenAtom);
   const setAuthData = useSetAtom(authAtom);
 
   const { mutateAsync: getMe } = useAuth();
 
   return useMutation({
-    mutationFn: (data: UserProfileEditData) => editUserProfile(token, data),
+    mutationFn: (data: UserProfileEditData) =>
+      editUserProfile(accessToken!, data),
     onSuccess: async () => {
-      const user = await getMe(token);
+      const accessToken = atomStore.get(accessTokenAtom);
+      const user = await getMe(accessToken!);
 
       setAuthData(user);
       queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.BADGES });

--- a/src/features/user/hooks/useEditUserProfile.tsx
+++ b/src/features/user/hooks/useEditUserProfile.tsx
@@ -3,10 +3,9 @@
 import { USER_PATH, USER_QUERY_KEY } from '@/constants';
 import { useAuth } from '@/features/auth/hooks';
 import { getQueryClient } from '@/libs/tanstack-query';
-import atomStore from '@/store';
 import { accessTokenAtom, authAtom } from '@/store/atoms';
 import { useMutation } from '@tanstack/react-query';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { getDefaultStore, useAtomValue, useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { UserProfileEditData } from '../schemas';
 import { editUserProfile } from '../services';
@@ -25,7 +24,8 @@ export function useEditUserProfile() {
     mutationFn: (data: UserProfileEditData) =>
       editUserProfile(accessToken!, data),
     onSuccess: async () => {
-      const accessToken = atomStore.get(accessTokenAtom);
+      const store = getDefaultStore();
+      const accessToken = store.get(accessTokenAtom);
       const user = await getMe(accessToken!);
 
       setAuthData(user);

--- a/src/features/user/hooks/useWithdraw.tsx
+++ b/src/features/user/hooks/useWithdraw.tsx
@@ -2,7 +2,7 @@
 
 import { ROOT_PATH } from '@/constants';
 import { withdraw } from '@/features/user/services';
-import { accessTokenAtom, authAtom } from '@/store';
+import { accessTokenAtom, authAtom } from '@/store/atoms';
 import { useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';

--- a/src/providers.tsx
+++ b/src/providers.tsx
@@ -3,13 +3,11 @@
 import { getQueryClient } from '@/libs/tanstack-query';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { Provider as JotaiProvider } from 'jotai';
-import atomStore from './store';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={getQueryClient()}>
-      <JotaiProvider store={atomStore}>{children}</JotaiProvider>
+      {children}
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/src/providers.tsx
+++ b/src/providers.tsx
@@ -4,11 +4,12 @@ import { getQueryClient } from '@/libs/tanstack-query';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Provider as JotaiProvider } from 'jotai';
+import atomStore from './store';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={getQueryClient()}>
-      <JotaiProvider>{children}</JotaiProvider>
+      <JotaiProvider store={atomStore}>{children}</JotaiProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,1 +1,5 @@
-export * from './atoms';
+import { createStore } from 'jotai';
+
+const atomStore = createStore();
+
+export default atomStore;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,0 @@
-import { createStore } from 'jotai';
-
-const atomStore = createStore();
-
-export default atomStore;

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -1,7 +1,7 @@
 import { refresh } from '@/features/auth/services';
 import { InfiniteScrollResponse, PaginationMeta } from '@/schemas';
-import atomStore from '@/store';
 import { accessTokenAtom } from '@/store/atoms';
+import { getDefaultStore } from 'jotai';
 import { ApiError } from './error';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -79,17 +79,19 @@ const refreshRequest = async <T>(
   } catch (error) {
     if (error instanceof ApiError && error.statusCode === 401) {
       if (!isRefreshing) {
+        const store = getDefaultStore();
+
         try {
           isRefreshing = true;
 
           const refreshResponse = await refresh();
           const newAccessToken = refreshResponse!.accessToken;
 
-          atomStore.set(accessTokenAtom, newAccessToken);
+          store.set(accessTokenAtom, newAccessToken);
 
           return await request(newAccessToken);
         } catch {
-          atomStore.set(accessTokenAtom, null);
+          store.set(accessTokenAtom, null);
 
           window.location.href = '/login';
         } finally {

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -1,4 +1,7 @@
+import { refresh } from '@/features/auth/services';
 import { InfiniteScrollResponse, PaginationMeta } from '@/schemas';
+import atomStore from '@/store';
+import { accessTokenAtom } from '@/store/atoms';
 import { ApiError } from './error';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -65,18 +68,55 @@ export const infiniteApiClient = async <T, M = PaginationMeta>(
   return fetchWithConfig<InfiniteScrollResponse<T, M>>(endpoint, config);
 };
 
+let isRefreshing = false;
+
+const refreshRequest = async <T>(
+  token: string,
+  request: (token: string) => Promise<T>,
+) => {
+  try {
+    return await request(token);
+  } catch (error) {
+    if (error instanceof ApiError && error.statusCode === 401) {
+      if (!isRefreshing) {
+        try {
+          isRefreshing = true;
+
+          const refreshResponse = await refresh();
+          const newAccessToken = refreshResponse!.accessToken;
+
+          atomStore.set(accessTokenAtom, newAccessToken);
+
+          return await request(newAccessToken);
+        } catch {
+          atomStore.set(accessTokenAtom, null);
+
+          window.location.href = '/login';
+        } finally {
+          isRefreshing = false;
+        }
+      }
+    }
+
+    throw error;
+  }
+};
+
 export const authApiClient = async <T>(
   endpoint: string,
   token: string,
   config: RequestConfig = {},
 ) => {
-  return apiClient<T>(endpoint, {
-    ...config,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      ...config.headers,
-    },
-  });
+  const request = (accessToken: string) =>
+    apiClient<T>(endpoint, {
+      ...config,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        ...config.headers,
+      },
+    });
+
+  return refreshRequest(token, request);
 };
 
 export const authInfiniteApiClient = <T, M = PaginationMeta>(
@@ -84,11 +124,14 @@ export const authInfiniteApiClient = <T, M = PaginationMeta>(
   token: string,
   config: RequestConfig = {},
 ) => {
-  return infiniteApiClient<T, M>(endpoint, {
-    ...config,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      ...config.headers,
-    },
-  });
+  const request = (accessToken: string) =>
+    infiniteApiClient<T, M>(endpoint, {
+      ...config,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        ...config.headers,
+      },
+    });
+
+  return refreshRequest(token, request);
 };


### PR DESCRIPTION
## ⭐Key Changes

1. 권한이 필요한 요청에 대한 401 에러 발생 시 캐치하여 Access Token 재발급 및 업데이트합니다.
2. 커스텀 fetch 함수(`refreshRequest`)에 401 에러에 대한 에러처리(`try...catch`)를 추가하고, 재발급 받은 `access token`을 jotai 스토어에 업데이트한 후 기존 요청을 다시 보내는 형식으로 구현했습니다.

<br />

## 🖐️To reviewers

1. 기능 구현 외에 `atom` 파일들의 `export` 경로 수정이 있어 변경 파일이 많이 생겼습니다.
  기존: `"@/store"` -> `"@/store/atoms"`

<br />

## 📌 issue

- close #162 
