### PR TITLE
프로필이미지 사이즈가  채워지지 않는 문제 해결

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,7 @@ export * from './error-handling-wrapper';
 export * from './form';
 export * from './header';
 export * from './modal';
+export * from './profile-image';
 export * from './skeleton-box';
 export * from './text-input';
 export * from './textarea';

--- a/src/components/profile-image/ProfileImage.tsx
+++ b/src/components/profile-image/ProfileImage.tsx
@@ -1,0 +1,31 @@
+import { cn } from '@/utils/style';
+import Image from 'next/image';
+
+type ProfileImageProps = {
+  src: string;
+  alt: string;
+  size: 'sm' | 'md' | 'lg';
+  priority?: boolean;
+};
+
+export function ProfileImage({ src, alt, size, priority }: ProfileImageProps) {
+  const sizes = size === 'sm' ? '40px' : size === 'md' ? '52px' : '64px';
+
+  return (
+    <div
+      className={cn(
+        'relative shrink-0 overflow-hidden rounded-full',
+        size === 'sm' ? 'w-10 h-10' : size === 'md' ? 'w-13 h-13' : 'w-16 h-16',
+      )}
+    >
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        sizes={sizes}
+        className="object-cover"
+        priority={priority}
+      />
+    </div>
+  );
+}

--- a/src/components/profile-image/index.ts
+++ b/src/components/profile-image/index.ts
@@ -1,0 +1,1 @@
+export * from './ProfileImage';

--- a/src/features/comment/components/comment-item/CommentItem.tsx
+++ b/src/features/comment/components/comment-item/CommentItem.tsx
@@ -1,9 +1,9 @@
+import { ProfileImage } from '@/components';
 import { COURSE } from '@/constants';
 import { useOutsideClick } from '@/hooks';
 import { authAtom } from '@/store/atoms';
 import { dateDistance } from '@/utils/date';
 import { useAtomValue } from 'jotai';
-import Image from 'next/image';
 import { useRef, useState } from 'react';
 import { CommentItem as CommentItemType } from '../../schemas';
 import { CommentMenu } from './CommentMenu';
@@ -27,15 +27,7 @@ export function CommentItem({ comment }: CommentItemProps) {
   return (
     <li className="border-b border-light-grey last:border-b-0">
       <div className="flex justify-start items-start gap-4 pt-3 pb-6 mx-1">
-        <div className="relative w-10 h-10 shrink-0 overflow-hidden rounded-full">
-          <Image
-            src={profileImageUrl}
-            alt={name}
-            fill
-            sizes="40px"
-            className="object-cover"
-          />
-        </div>
+        <ProfileImage src={profileImageUrl} alt={name} size="sm" />
         <div className="flex flex-col w-full">
           <div className="w-full">
             <div className="relative flex justify-between items-center">

--- a/src/features/project/components/project-detail-container/MemberItem.tsx
+++ b/src/features/project/components/project-detail-container/MemberItem.tsx
@@ -1,5 +1,5 @@
+import { ProfileImage } from '@/components';
 import { COURSE } from '@/constants';
-import Image from 'next/image';
 import { TeamMember } from '../../schemas';
 
 type MemberItemProps = {
@@ -13,15 +13,7 @@ export function MemberItem({ member }: MemberItemProps) {
       key={id}
       className="flex items-center gap-4 py-3 mx-1 border-b border-light-grey"
     >
-      <div className="relative w-13 h-13 shrink-0 overflow-hidden rounded-full">
-        <Image
-          src={profileImageUrl}
-          alt={name}
-          fill
-          sizes="52px"
-          className="object-cover"
-        />
-      </div>
+      <ProfileImage src={profileImageUrl} alt={name} size="md" />
       <div>
         <p className="font-medium">
           {nickname}({name})

--- a/src/features/user/components/information/Information.tsx
+++ b/src/features/user/components/information/Information.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { ProfileImage } from '@/components';
 import { NavArrowIcon } from '@/components/icons';
 import { COURSE, USER_PATH } from '@/constants';
 import { authAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
 export function Information() {
@@ -25,16 +25,12 @@ export function Information() {
     <section className="flex flex-col gap-4 w-full mb-12">
       <h2 className="text-lg font-semibold">회원 정보</h2>
       <div className="flex gap-4">
-        <div className="relative h-16 w-16 overflow-hidden shrink-0 rounded-full">
-          <Image
-            src={profileImageUrl}
-            alt="프로필 이미지"
-            fill
-            sizes="64px"
-            priority
-            className="object-cover"
-          />
-        </div>
+        <ProfileImage
+          src={profileImageUrl}
+          alt="프로필 이미지"
+          size="lg"
+          priority
+        />
         <div className="flex flex-col justify-center gap-1 text-sm">
           <div className="flex items-center gap-4">
             <p className="text-base font-semibold">


### PR DESCRIPTION
## ⭐Key Changes

1. 이미지 최적화 과정에서 sizes를 수정하면서 크기가 고정된 요소의 경우 `width`와 `height`를 설정했는데, 가로/세로 비율이 다른 이미지의 경우 큰 사이즈에 맞춰져서 원모양에 꽉 차지 않는 문제가 있었습니다. 이를 `fill` 속성을 사용해서 해결했습니다.

|   수정전  |  수정후  |
| ------- | ------- |
| <img width="69" alt="수정전" src="https://github.com/user-attachments/assets/8d5fda51-a95c-4805-b081-99d24098b815" /> | <img width="68" alt="수정후" src="https://github.com/user-attachments/assets/4243e31e-fdd3-41e8-89da-c21ef094af68" /> |

