### PR TITLE
마이페이지 구독프로젝트 개수 및 챗봇 채팅 길이 수정

### DIFF
--- a/src/features/chatbot/components/chatting-item/ChattingItem.tsx
+++ b/src/features/chatbot/components/chatting-item/ChattingItem.tsx
@@ -26,7 +26,7 @@ export function ChattingItem({ content, isUser }: ChattingItemProps) {
       )}
       <pre
         className={cn(
-          'text-sm px-3 py-2 bg-white rounded-xl max-w-4/5 whitespace-pre-wrap break-words',
+          'text-sm px-3 py-2 bg-white rounded-xl max-w-4/5 w-fit whitespace-pre-wrap break-words',
           isUser && 'self-end',
         )}
       >

--- a/src/features/user/components/subscribed-projects/SubscribedProjects.tsx
+++ b/src/features/user/components/subscribed-projects/SubscribedProjects.tsx
@@ -9,7 +9,7 @@ export function SubscribedProjects() {
   const authData = useAtomValue(authAtom);
 
   const { data } = useSubscribedProjects(authData!.term as Term, 3);
-  const projects = data.pages.flatMap((page) => page.data);
+  const projects = data.pages.flatMap((page) => page.data).slice(0, 3);
   return (
     <ul className="flex flex-col gap-5">
       {projects.map((project) => (


### PR DESCRIPTION
## ⭐Key Changes

1. 마이페이지의 구독 프로젝트 목록에서 구독 프로젝트 페이지와 동일한 쿼리를 공유해서, 구독 프로젝트 페이지에 갔다가 마이페이지에 오면 3개가 넘는 프로젝트를 보여주는 문제를 `slice`를 사용해서 제한했습니다.
2. 챗봇 채팅에서 길이가 짧은 경우에도 너비를 채우는 문제를 질문 또는 응답의 길이에 맞게 해결했습니다.

