### PR TITLE
외부인인 경우 마이페이지에서 에러뜨는 문제 해결

### DIFF
--- a/src/features/badge/components/badges-container/BadgesContainer.tsx
+++ b/src/features/badge/components/badges-container/BadgesContainer.tsx
@@ -1,25 +1,30 @@
 'use client';
 
 import { ErrorHandlingWrapper } from '@/components';
-import { accessTokenAtom } from '@/store/atoms';
+import { accessTokenAtom, authAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
 import { BadgeErrorFallback } from './BadgeErrorFallback';
 import { BadgeFallback } from './BadgeFallback';
 import { BadgesFetcher } from './BadgesFetcher';
 
 export function BadgesContainer() {
+  const authData = useAtomValue(authAtom);
   const accessToken = useAtomValue(accessTokenAtom);
 
-  if (!accessToken) return null;
+  if (!accessToken || !authData) return null;
+
+  const isTrainee = authData && authData.course;
 
   return (
-    <div className="mb-12 w-full">
-      <ErrorHandlingWrapper
-        ErrorFallback={<BadgeErrorFallback />}
-        SuspenseFallback={<BadgeFallback />}
-      >
-        <BadgesFetcher />
-      </ErrorHandlingWrapper>
-    </div>
+    isTrainee && (
+      <div className="mb-12 w-full">
+        <ErrorHandlingWrapper
+          ErrorFallback={<BadgeErrorFallback />}
+          SuspenseFallback={<BadgeFallback />}
+        >
+          <BadgesFetcher />
+        </ErrorHandlingWrapper>
+      </div>
+    )
   );
 }

--- a/src/features/user/components/dashboard/DashboardContainer.tsx
+++ b/src/features/user/components/dashboard/DashboardContainer.tsx
@@ -25,17 +25,21 @@ export function DashboardContainer() {
 
   if (!authData) return null;
 
+  const isTrainee = authData && authData.course;
+
   const handleToggleEmailConsent = () => {
     toggleEmailConsent();
   };
   return (
     <div className="mb-12 w-full">
-      <ErrorHandlingWrapper
-        ErrorFallback={<DashboardErrorFallback />}
-        SuspenseFallback={<DashboardFallback />}
-      >
-        <DashboardFetcher />
-      </ErrorHandlingWrapper>
+      {isTrainee && (
+        <ErrorHandlingWrapper
+          ErrorFallback={<DashboardErrorFallback />}
+          SuspenseFallback={<DashboardFallback />}
+        >
+          <DashboardFetcher />
+        </ErrorHandlingWrapper>
+      )}
       <div className="flex justify-between items-center w-fullw-full mt-4">
         <div className="flex items-center gap-3">
           <Tooltip direction="right">

--- a/src/features/user/components/information/Information.tsx
+++ b/src/features/user/components/information/Information.tsx
@@ -4,6 +4,7 @@ import { ProfileImage } from '@/components';
 import { NavArrowIcon } from '@/components/icons';
 import { COURSE, USER_PATH } from '@/constants';
 import { authAtom } from '@/store/atoms';
+import { cn } from '@/utils/style';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 
@@ -11,18 +12,17 @@ export function Information() {
   const router = useRouter();
   const authData = useAtomValue(authAtom);
 
-  if (!authData) {
-    return null;
-  }
+  if (!authData) return null;
 
   const { term, teamNumber, email, name, nickname, profileImageUrl, course } =
     authData;
+  const isTrainee = authData && course;
 
   const handleEditClick = () => {
     router.push(USER_PATH.MY_PAGE_EDIT);
   };
   return (
-    <section className="flex flex-col gap-4 w-full mb-12">
+    <section className={cn('flex flex-col gap-4 w-full', isTrainee && 'mb-12')}>
       <h2 className="text-lg font-semibold">회원 정보</h2>
       <div className="flex gap-4">
         <ProfileImage

--- a/src/features/user/components/subscribed-projects/SubscribedProjects.tsx
+++ b/src/features/user/components/subscribed-projects/SubscribedProjects.tsx
@@ -11,7 +11,7 @@ import BrowseSubscribedProjectsButton from './BrowseSubscribedProjectsButton';
 export function SubscribedProjects() {
   const authData = useAtomValue(authAtom);
 
-  const { data } = useSubscribedProjects(authData!.term as Term, 3);
+  const { data } = useSubscribedProjects((authData?.term as Term) || 2, 3);
   const projects = data.pages.flatMap((page) => page.data).slice(0, 3);
 
   const hasSubscribedProjects = projects.length > 0;


### PR DESCRIPTION
## ⭐Key Changes

1. 외부인인 경우 유저 데이터에 team 정보가 없어 마이페이지에서 발생하는 에러를 이제 발견하고 수정했습니다.
<div align="center">
<img width="297" height="672" alt="마이페이지 에러" src="https://github.com/user-attachments/assets/37e997ac-4cb0-43f8-a9db-b3e03ca04cf2" />
</div>

<br />

## 🖐️To reviewers

1. 회원 정보에서 교육생 여부를 판단하고 교육생이 아닌 경우 대시보드와 뱃지 데이터는 요청하지 않고, 구독 프로젝트의 경우 본인 기수를 기준으로 요청하고 있었는데, 없는 경우 2기의 데이터를 불러오도록 수정했습니다.

<br />

## 📌 issue

- close #197 
